### PR TITLE
Give Models a Reference to Their Endpoint

### DIFF
--- a/src/Resource/Endpoint.php
+++ b/src/Resource/Endpoint.php
@@ -69,7 +69,7 @@ abstract class Endpoint implements Readable {
    */
   public function getModel(int $id = null) : Model {
     $fqcn = static::_MODEL_FQCN;
-    return new $fqcn($id);
+    return new $fqcn($id, $this);
   }
 
   /**
@@ -89,9 +89,7 @@ abstract class Endpoint implements Readable {
         );
       }
 
-      $item = $this->getModel();
-      $item->sync($data);
-      $collection->add($item);
+      $collection->add($this->getModel()->sync($data));
     }
 
     // this might end up being redundant,

--- a/src/Resource/ResourceException.php
+++ b/src/Resource/ResourceException.php
@@ -43,6 +43,9 @@ class ResourceException extends Exception {
   /** @var int Invalid filter callback. */
   const INVALID_FILTER = 9;
 
+  /** @var int Attempt to use an api method when no endpoint is available. */
+  const NO_ENDPOINT_AVAILABLE = 10;
+
   /** {@inheritDoc} */
   const INFO = [
     self::NO_SUCH_PROPERTY => ['message' => 'resource.no_such_property'],
@@ -56,6 +59,8 @@ class ResourceException extends Exception {
       ['message' => 'resource.wrong_model_for_collection'],
     self::WAIT_TIMEOUT_EXCEEDED =>
       ['message' => 'resource.wait_timeout_exceeded'],
-    self::INVALID_FILTER => ['message' => 'resource.invalid_filter']
+    self::INVALID_FILTER => ['message' => 'resource.invalid_filter'],
+    self::NO_ENDPOINT_AVAILABLE =>
+      ['message' => 'resource.no_endpoint_available']
   ];
 }

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -20,6 +20,7 @@
   "resource": {
     "invalid_filter": "{class}::{method} expects $filter to be callable or array; {type} provided",
     "model_not_found": "No model {model}:{id} found",
+    "no_endpoint_available": "No Endpoint is available to make API calls; use Model::setApiEndpoint() or create your Models via SDK Client",
     "no_such_model": "No model {model} exists",
     "no_such_property": "No property '{name}' exists on {model}",
     "no_such_service_model": "No Service model exists for type: {type}",

--- a/tests/Resource/EndpointTestCase.php
+++ b/tests/Resource/EndpointTestCase.php
@@ -38,9 +38,17 @@ abstract class EndpointTestCase extends TestCase {
    */
   public function testGetModel() {
     $this->_getSandbox()->play(function ($api, $sandbox) {
-      $actual = $api->getEndpoint(static::_SUBJECT_FQCN)->getModel(1);
+      $endpoint = $api->getEndpoint(static::_SUBJECT_FQCN);
+      $actual = $endpoint->getModel(1);
+
       $this->assertInstanceOf(static::_SUBJECT_MODEL_FQCN, $actual);
       $this->assertEquals(1, $actual->getId(), 'Must set given model id');
+
+      $this->assertEquals(
+        $this->_getNonpublicProperty($actual, '_endpoint'),
+        $endpoint,
+        'Must assign endpoint to new model'
+      );
     });
   }
 

--- a/tests/Resource/ModelTestCase.php
+++ b/tests/Resource/ModelTestCase.php
@@ -13,6 +13,7 @@ use Throwable;
 
 use Nexcess\Sdk\ {
   Resource\Collection,
+  Resource\Endpoint,
   Resource\Model,
   Resource\ResourceException,
   Sandbox\Sandbox,
@@ -268,6 +269,23 @@ abstract class ModelTestCase extends TestCase {
   public function testIsReal() {
     $this->assertTrue($this->_getSubject(1)->isReal());
     $this->assertFalse($this->_getSubject(0)->isReal());
+  }
+
+  /**
+   * @covers Model::setApiEndpoint
+   */
+  public function testSetApiEndpoint() {
+    $endpoint = new class extends Endpoint {
+      public function __construct() {}
+    };
+    $model = $this->_getSubject(1);
+    $model->setApiEndpoint($endpoint);
+
+    $this->assertEquals(
+      $this->_getNonpublicProperty($model, '_endpoint'),
+      $endpoint,
+      'Must assign given endpoint to model'
+    );
   }
 
   /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,10 +9,9 @@ declare(strict_types  = 1);
 
 namespace Nexcess\Sdk\Tests;
 
-use Throwable;
-
+use ReflectionObject,
+  Throwable;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
-
 use Nexcess\Sdk\ {
   Sandbox\Sandbox,
   Tests\TestException,
@@ -43,6 +42,24 @@ abstract class TestCase extends PHPUnitTestCase {
     if (! empty($code)) {
       $this->expectExceptionCode($code);
     }
+  }
+
+  /**
+   * Gets the value of a nonpublic property of an object under test.
+   *
+   * @param object $object The object to inspect
+   * @param string $property The property to access
+   * @return mixed|null The property's value if exists; null otherwise
+   */
+  protected function _getNonpublicProperty($object, string $property) {
+    $ro = new ReflectionObject($object);
+    if (! $ro->hasProperty($property)) {
+      return null;
+    }
+
+    $rp = $ro->getProperty($property);
+    $rp->setAccessible(true);
+    return $rp->getValue($object);
   }
 
   /**


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-11559

This makes a resource's endpoint automatically available to the instance, allowing api actions to be called directly on the resource model.
```php
<?php

$resource->doSomething(); 

// no longer have to do 
$endpoint->doSomething($resource);
```

Note this does not proxy methods _automagically_, but allows the resource class to implement as appropriate.