### PR TITLE
Rename Resource → Entity

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -229,7 +229,7 @@ class Client {
    * (as opposed to using `new`),
    * as it will associate them with their correct endpoint(s) automatically.
    *
-   * @param string $name Resource FQCN or module name
+   * @param string $name Entity FQCN or module name
    * @return Model
    * @throws SdkException If the model is unknown
    */
@@ -237,7 +237,7 @@ class Client {
     if (is_a($name, Model::class, true)) {
       $model = $name;
     } else {
-      $model = static::RESOURCE_NAMESPACE . "\\{$name}\\Resource";
+      $model = static::RESOURCE_NAMESPACE . "\\{$name}\\Entity";
 
       if (! is_a($model, Model::class, true)) {
         throw new SdkException(SdkException::NO_SUCH_MODEL, ['name' => $name]);

--- a/src/Resource/ApiToken/Endpoint.php
+++ b/src/Resource/ApiToken/Endpoint.php
@@ -10,7 +10,7 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\ApiToken;
 
 use Nexcess\Sdk\ {
-  Resource\ApiToken\Resource,
+  Resource\ApiToken\Entity,
   Resource\CanCreate,
   Resource\CanDelete,
   Resource\CanUpdate,
@@ -36,7 +36,7 @@ class Endpoint
   protected const _URI = 'api-token';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /** {@inheritDoc} */
   protected const _PARAMS = [

--- a/src/Resource/ApiToken/Entity.php
+++ b/src/Resource/ApiToken/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * API Token.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'ApiToken';

--- a/src/Resource/App/Endpoint.php
+++ b/src/Resource/App/Endpoint.php
@@ -10,7 +10,7 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\App;
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource,
+  Resource\App\Entity,
   Resource\Endpoint as ReadableEndpoint
 };
 
@@ -26,5 +26,5 @@ class Endpoint extends ReadableEndpoint {
   protected const _URI = 'app';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 }

--- a/src/Resource/App/Entity.php
+++ b/src/Resource/App/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * Represents an App Environment for a cloud account.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'App';

--- a/src/Resource/Cloud/Endpoint.php
+++ b/src/Resource/Cloud/Endpoint.php
@@ -10,7 +10,7 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\Cloud;
 
 use Nexcess\Sdk\ {
-  Resource\Cloud\Resource,
+  Resource\Cloud\Entity,
   Resource\Endpoint as ReadableEndpoint
 };
 
@@ -26,5 +26,5 @@ class Endpoint extends ReadableEndpoint {
   protected const _URI = 'virt-cloud';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 }

--- a/src/Resource/Cloud/Entity.php
+++ b/src/Resource/Cloud/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * Represents a cloud (e.g., servers that do cloud stuff).
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'Cloud';

--- a/src/Resource/CloudAccount/Endpoint.php
+++ b/src/Resource/CloudAccount/Endpoint.php
@@ -12,7 +12,7 @@ namespace Nexcess\Sdk\Resource\CloudAccount;
 use Nexcess\Sdk\ {
   ApiException,
   Resource\CanCreate,
-  Resource\CloudAccount\Resource,
+  Resource\CloudAccount\Entity,
   Resource\Creatable,
   Resource\Endpoint as BaseEndpoint,
   Util\Util
@@ -31,7 +31,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
   protected const _URI = 'cloud-account';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /** {@inheritDoc} */
   protected const _PARAMS = [
@@ -52,34 +52,34 @@ class Endpoint extends BaseEndpoint implements Creatable {
    * and does not delete the cloud account directly.
    * Use this method to cancel a primary cloud account, not a dev account.
    *
-   * @param Resource $resource Cloud Server resource
+   * @param Entity $entity Cloud Server instance
    * @param array $survey Cancellation survey
    * @return Endpoint $this
    */
-  public function cancel(Resource $resource, array $survey) : Endpoint {
-    $resource->get('service')->cancel($survey);
+  public function cancel(Entity $entity, array $survey) : Endpoint {
+    $entity->get('service')->cancel($survey);
     return $this;
   }
 
   /**
    * Switches PHP versions active on an existing cloud account.
    *
-   * @param Resource $resource Cloud server instance
+   * @param Entity $entity Cloud server instance
    * @param string $version Desired PHP version
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
   public function setPhpVersion(
-    Resource $resource,
+    Entity $entity,
     string $version
   ) : Endpoint {
     $this->_client->request(
       'POST',
-      self::_URI . "/{$resource->getId()}",
+      self::_URI . "/{$entity->getId()}",
       ['json' => ['_action' => 'set-php-version', 'php_version' => $version]]
     );
 
-    $this->_wait($this->_waitForPhpVersion($resource, $version));
+    $this->_wait($this->_waitForPhpVersion($entity, $version));
 
     return $this;
   }
@@ -87,17 +87,17 @@ class Endpoint extends BaseEndpoint implements Creatable {
   /**
    * Builds callback to wait() for a cloud account to update php versions.
    *
-   * @param Resource $resource The CloudAccount instance to check
+   * @param Entity $entity The CloudAccount instance to check
    * @param string $version The target php version
    * @return Closure Callback for wait()
    */
   protected function _waitForPhpVersion(
-    Resource $resource,
+    Entity $entity,
     string $version
   ) : Closure {
-    return function (Endpoint $endpoint) use ($resource, $version) {
-      $resource->sync($this->_retrieve($resource->getId()));
-      return $resource->get('php_version') === $version;
+    return function (Endpoint $endpoint) use ($entity, $version) {
+      $entity->sync($this->_retrieve($entity->getId()));
+      return $entity->get('php_version') === $version;
     };
   }
 }

--- a/src/Resource/CloudAccount/Entity.php
+++ b/src/Resource/CloudAccount/Entity.php
@@ -10,16 +10,16 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\CloudAccount;
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource as App,
+  Resource\App\Entity as App,
   Resource\Model,
-  Resource\VirtGuestCloud\Resource as Service,
+  Resource\VirtGuestCloud\Entity as Service,
   Util\Util
 };
 
 /**
  * Cloud Account (virtual hosting).
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'CloudAccount';
@@ -76,11 +76,11 @@ class Resource extends Model {
    * Switches PHP version on this cloud account.
    *
    * @param string $version Target PHP version
-   * @return Resource $this
+   * @return Entity $this
    * @throws ResourceException If endpoint not available
    * @throws ApiException If request fails
    */
-  public function setPhpVersion(string $version) : Resource {
+  public function setPhpVersion(string $version) : Entity {
     $this->_getEndpoint()->setPhpVersion($this, $version)->wait();
     return $this;
   }

--- a/src/Resource/CloudServer/Endpoint.php
+++ b/src/Resource/CloudServer/Endpoint.php
@@ -10,7 +10,7 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\CloudServer;
 
 use Nexcess\Sdk\ {
-  Resource\CloudServer\Resource,
+  Resource\CloudServer\Entity,
   Resource\Service\Endpoint as ServiceEndpoint
 };
 
@@ -26,23 +26,23 @@ class Endpoint extends ServiceEndpoint {
   protected const _SERVICE_TYPE = 'virt-guest';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /**
    * Reboots an existing cloud server.
    *
-   * @param Resource $resource Cloud Server model
+   * @param Entity $entity Cloud Server model
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
-  public function reboot(Resource $resource) : Endpoint {
+  public function reboot(Entity $entity) : Endpoint {
     $this->_client->request(
       'POST',
-      self::_URI . "/{$resource->getId()}",
+      self::_URI . "/{$entity->getId()}",
       ['json' => ['_action' => 'reboot']]
     );
 
-    $this->_wait($this->_waitForStart($resource));
+    $this->_wait($this->_waitForStart($entity));
 
     return $this;
   }
@@ -50,22 +50,19 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Resizes an existing cloud server.
    *
-   * @param Resource $resource Cloud Server model
+   * @param Entity $entity Cloud Server model
    * @param int $package_id Desired package id
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
-  public function resize(
-    Resource $resource,
-    int $package_id
-  ) : Endpoint {
+  public function resize(Entity $entity, int $package_id) : Endpoint {
     $this->_client->request(
       'POST',
-      self::_URI . "/{$resource->getId()}",
+      self::_URI . "/{$entity->getId()}",
       ['json' => ['_action' => 'resize', 'package_id' => $package_id]]
     );
 
-    $this->_wait($this->_waitForResize($resource));
+    $this->_wait($this->_waitForResize($entity));
 
     return $this;
   }
@@ -73,18 +70,18 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Starts an existing cloud server.
    *
-   * @param Resource $resource Cloud Server model
+   * @param Entity $entity Cloud Server model
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
-  public function start(Resource $resource) : Endpoint {
+  public function start(Entity $entity) : Endpoint {
     $this->_client->request(
       'POST',
-      self::_URI . "/{$resource->getId()}",
+      self::_URI . "/{$entity->getId()}",
       ['json' => ['_action' => 'start']]
     );
 
-    $this->_wait($this->_waitForStart($resource));
+    $this->_wait($this->_waitForStart($entity));
 
     return $this;
   }
@@ -92,18 +89,18 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Stops an existing cloud server.
    *
-   * @param Resource $resource Cloud Server model
+   * @param Entity $entity Cloud Server model
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
-  public function stop(Resource $resource) : Endpoint {
+  public function stop(Entity $entity) : Endpoint {
     $this->_client->request(
       'POST',
-      self::_URI . "/{$resource->getId()}",
+      self::_URI . "/{$entity->getId()}",
       ['json' => ['_action' => 'stop']]
     );
 
-    $this->_wait($this->_waitForStop($resource));
+    $this->_wait($this->_waitForStop($entity));
 
     return $this;
   }
@@ -111,16 +108,16 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Views an existing cloud server's console log.
    *
-   * @param Resource $resource Cloud Server model
+   * @param Entity $entity Cloud Server model
    * @return string[] Lines from console log file
    * @throws ApiException If request fails
    */
-  public function viewConsoleLog(Resource $resource) : array {
+  public function viewConsoleLog(Entity $entity) : array {
     return explode(
       "\n",
       $this->_client->request(
         'POST',
-        self::_URI . "/{$resource->getId()}",
+        self::_URI . "/{$entity->getId()}",
         ['_action' => 'console-log']
       )
     );
@@ -129,44 +126,44 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Builds callback to wait() for a cloud server to turn on.
    *
-   * @param Resource $resource The CloudServer instance to check
+   * @param Entity $entity The CloudServer instance to check
    * @return Closure Callback for wait()
    */
-  protected function _waitForStart(Resource $resource) : Closure {
-    return function (Endpoint $endpoint) use ($resource) {
-      $resource->sync($this->_retrieve($resource->getId()));
-      return $resource->get('power_status') === 'on';
+  protected function _waitForStart(Entity $entity) : Closure {
+    return function (Endpoint $endpoint) use ($entity) {
+      $entity->sync($this->_retrieve($entity->getId()));
+      return $entity->get('power_status') === 'on';
     };
   }
 
   /**
    * Builds callback to wait() for a cloud server to turn off.
    *
-   * @param Resource $resource The CloudServer instance to check
+   * @param Entity $entity The CloudServer instance to check
    * @return Closure Callback for wait()
    */
-  protected function _waitForStop(Resource $resource) : Closure {
-    return function (Endpoint $endpoint) use ($resource) {
-      $resource->sync($this->_retrieve($resource->getId()));
-      return $resource->get('power_status') === 'off';
+  protected function _waitForStop(Entity $entity) : Closure {
+    return function (Endpoint $endpoint) use ($entity) {
+      $entity->sync($this->_retrieve($entity->getId()));
+      return $entity->get('power_status') === 'off';
     };
   }
 
   /**
    * Builds callback to wait() for a cloud server to be resized.
    *
-   * @param Resource $resource The CloudServer instance to check
+   * @param Entity $entity The CloudServer instance to check
    * @param int $package_id The resized package id
    * @return Closure Callback for wait()
    */
   protected function _waitForResize(
-    Resource $resource,
+    Entity $entity,
     int $package_id
   ) : Closure {
-    return function (Endpoint $endpoint) use ($resource, $package_id) {
-      $resource->sync($this->_retrieve($resource->getId()));
-      return $resource->get('package_id') === $package_id &&
-        $resource->get('state') === 'stable';
+    return function (Endpoint $endpoint) use ($entity, $package_id) {
+      $entity->sync($this->_retrieve($entity->getId()));
+      return $entity->get('package_id') === $package_id &&
+        $entity->get('state') === 'stable';
     };
   }
 }

--- a/src/Resource/CloudServer/Entity.php
+++ b/src/Resource/CloudServer/Entity.php
@@ -10,16 +10,16 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\CloudServer;
 
 use Nexcess\Sdk\ {
-  Resource\Cloud\Resource as Cloud,
-  Resource\Location\Resource as Location,
-  Resource\Package\Resource as Package,
-  Resource\Service\Resource as Service
+  Resource\Cloud\Entity as Cloud,
+  Resource\Location\Entity as Location,
+  Resource\Package\Entity as Package,
+  Resource\Service\Entity as Service
 };
 
 /**
  * Cloud Server (virtual machine).
  */
-class Resource extends Service {
+class Entity extends Service {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'CloudServer';

--- a/src/Resource/Invoice/Endpoint.php
+++ b/src/Resource/Invoice/Endpoint.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Resource\Invoice;
 
 use Nexcess\Sdk\ {
   Resource\Endpoint as ReadableEndpoint,
-  Resource\Invoice\Resource
+  Resource\Invoice\Entity
 };
 
 /**
@@ -23,7 +23,7 @@ class Endpoint extends ReadableEndpoint {
   public const MODULE_NAME = 'Invoice';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /** {@inheritDoc} */
   protected const _URI = 'invoice';

--- a/src/Resource/Invoice/Entity.php
+++ b/src/Resource/Invoice/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * Represents an Invoice.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'Invoice';

--- a/src/Resource/Order/Endpoint.php
+++ b/src/Resource/Order/Endpoint.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Resource\Order;
 
 use Nexcess\Sdk\ {
   Resource\Endpoint as ReadableEndpoint,
-  Resource\Order\Order
+  Resource\Order\Entity
 };
 
 /**
@@ -23,7 +23,7 @@ class Endpoint extends ReadableEndpoint {
   public const MODULE_NAME = 'Order';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Order::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /** {@inheritDoc} */
   protected const _URI = 'order';

--- a/src/Resource/Order/Entity.php
+++ b/src/Resource/Order/Entity.php
@@ -10,14 +10,14 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\Order;
 
 use Nexcess\Sdk\ {
-  Resource\Client\Resource as Client,
-  Resource\Cloud\Resource as Cloud,
-  Resource\Invoice\Resource as Invoice,
+  Resource\Client\Entity as Client,
+  Resource\Cloud\Entity as Cloud,
+  Resource\Invoice\Entity as Invoice,
   Resource\Model,
   Resource\Order\OrderException,
-  Resource\Package\Resource as Package,
+  Resource\Package\Entity as Package,
   Resource\Service\Endpoint as ServiceEndpoint,
-  Resource\Service\Resource as Service,
+  Resource\Service\Entity as Service,
   SdkException,
   Util\Util
 };
@@ -25,7 +25,7 @@ use Nexcess\Sdk\ {
 /**
  * Orders.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'Order';

--- a/src/Resource/Package/Endpoint.php
+++ b/src/Resource/Package/Endpoint.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Resource\Package;
 
 use Nexcess\Sdk\ {
   Resource\Endpoint as ReadableEndpoint,
-  Resource\Package\Resource,
+  Resource\Package\Entity,
   Resource\Package\PackageException
 };
 
@@ -27,7 +27,7 @@ class Endpoint extends ReadableEndpoint {
   protected const _URI = 'package';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /**
    * {@inheritDoc}

--- a/src/Resource/Package/Entity.php
+++ b/src/Resource/Package/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * Represents a service package.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'Package';

--- a/src/Resource/Service/Endpoint.php
+++ b/src/Resource/Service/Endpoint.php
@@ -13,8 +13,9 @@ use Nexcess\Sdk\ {
   ApiException,
   Resource\CloudServer\Endpoint as CloudServer,
   Resource\Endpoint as BaseEndpoint,
+  Resource\Service\Entity,
   Resource\Service\ServiceException,
-  Resource\ServiceCancellation\Resource as ServiceCancellation,
+  Resource\ServiceCancellation\Entity as ServiceCancellation,
   Resource\VirtGuestCloud\Endpoint as VirtGuestCloud
 };
 
@@ -64,21 +65,21 @@ abstract class Endpoint extends BaseEndpoint {
   /**
    * Gets the questions for the cancellation survey for a service.
    *
-   * @param Service $model Service model to cancel
+   * @param Entity $entity Service to cancel
    * @return array List of cancellation survey questions + metadata
    */
-  public function getCancellationSurvey() : array {
+  public function getCancellationSurvey(Entity $entity) : array {
     throw new SdkException(
       SdkException::NOT_IMPLEMENTED,
       ['method' => __METHOD__]
     );
 
-    $this->_checkModelType($model);
+    $this->_checkModelType($entity);
 
-    if ($model->get('is_cancellable') !== true) {
+    if ($entity->get('is_cancellable') !== true) {
       throw new ServiceException(
         ServiceException::NOT_CANCELLABLE,
-        ['service' => static::_SERVICE_TYPE, 'id' => $model->getId()]
+        ['service' => static::_SERVICE_TYPE, 'id' => $entity->getId()]
       );
     }
 
@@ -88,26 +89,23 @@ abstract class Endpoint extends BaseEndpoint {
   /**
    * Requests a service cancellation.
    *
-   * @param Service $service Service model to cancel
+   * @param Entity $entity Service to cancel
    * @param array $survey Cancellation survey
    * @return ServiceCancellation
    * @throws ApiException If request fails
    */
-  public function cancel(
-    Service $service,
-    array $survey
-  ) : ServiceCancellation {
+  public function cancel(Entity $entity, array $survey) : ServiceCancellation {
     throw new SdkException(
       SdkException::NOT_IMPLEMENTED,
       ['method' => __METHOD__]
     );
 
-    $this->_checkModelType($service);
+    $this->_checkModelType($entity);
 
-    if ($service->get('is_cancellable') !== true) {
+    if ($entity->get('is_cancellable') !== true) {
       throw new ServiceException(
         ServiceException::NOT_CANCELLABLE,
-        ['service' => static::_SERVICE_TYPE, 'id' => $service->getId()]
+        ['service' => static::_SERVICE_TYPE, 'id' => $entity->getId()]
       );
     }
 

--- a/src/Resource/Service/Entity.php
+++ b/src/Resource/Service/Entity.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Resource\Service;
 
 use Nexcess\Sdk\Resource\Model;
 
-abstract class Resource extends Model {
+abstract class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'Service';

--- a/src/Resource/User/Endpoint.php
+++ b/src/Resource/User/Endpoint.php
@@ -12,7 +12,7 @@ namespace Nexcess\Sdk\Resource\User;
 
 use Nexcess\Sdk\ {
   Resource\Endpoint as BaseEndpoint,
-  Resource\User\Resource
+  Resource\User\Entity
 };
 
 /**
@@ -27,5 +27,5 @@ class Endpoint extends BaseEndpoint {
   protected const _URI = 'user';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 }

--- a/src/Resource/User/Entity.php
+++ b/src/Resource/User/Entity.php
@@ -14,7 +14,7 @@ use Nexcess\Sdk\Resource\Model;
 /**
  * Represents a portal User.
  */
-class Resource extends Model {
+class Entity extends Model {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'User';

--- a/src/Resource/VirtGuestCloud/Endpoint.php
+++ b/src/Resource/VirtGuestCloud/Endpoint.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Resource\VirtGuestCloud;
 
 use Nexcess\Sdk\ {
   Resource\Service\Endpoint as ServiceEndpoint,
-  Resource\VirtGuestCloud\Resource
+  Resource\VirtGuestCloud\Entity
 };
 
 /**
@@ -23,7 +23,7 @@ class Endpoint extends ServiceEndpoint {
   public const MODULE_NAME = 'VirtGuestCloud';
 
   /** {@inheritDoc} */
-  protected const _MODEL_FQCN = Resource::class;
+  protected const _MODEL_FQCN = Entity::class;
 
   /** {@inheritDoc} */
   protected const _SERVICE_TYPE = 'virt-guest-cloud';
@@ -31,16 +31,13 @@ class Endpoint extends ServiceEndpoint {
   /**
    * Switches PHP versions active on a service's primary cloud account.
    *
-   * @param Resource $resource Service instance
+   * @param Entity $entity Service instance
    * @param string $version Desired PHP version
    * @return Endpoint $this
    * @throws ApiException If request fails
    */
-  public function setPhpVersion(
-    Resource $resource,
-    string $version
-  ) : Endpoint {
-    $resource->get('cloud_account')->setPhpVersion($version);
+  public function setPhpVersion(Entity $entity, string $version) : Endpoint {
+    $entity->get('cloud_account')->setPhpVersion($version);
     return $this;
   }
 }

--- a/src/Resource/VirtGuestCloud/Entity.php
+++ b/src/Resource/VirtGuestCloud/Entity.php
@@ -10,18 +10,18 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Resource\VirtGuestCloud;
 
 use Nexcess\Sdk\ {
-  Resource\Cloud\Resource as Cloud,
-  Resource\CloudAccount\Resource as CloudAccount,
+  Resource\Cloud\Entity as Cloud,
+  Resource\CloudAccount\Entity as CloudAccount,
   Resource\Modelable,
-  Resource\Package\Resource as Package,
-  Resource\Order\Resource as Order,
-  Resource\Service\Resource as Service
+  Resource\Package\Entity as Package,
+  Resource\Order\Entity as Order,
+  Resource\Service\Entity as Service
 };
 
 /**
  * Cloud Account (virtual hosting) service object.
  */
-class Resource extends Service {
+class Entity extends Service {
 
   /** {@inheritDoc} */
   public const MODULE_NAME = 'VirtGuestCloud';

--- a/tests/Resource/ApiToken/EndpointTest.php
+++ b/tests/Resource/ApiToken/EndpointTest.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Tests\Resource\ApiToken;
 
 use Nexcess\Sdk\ {
   Resource\ApiToken\Endpoint,
-  Resource\ApiToken\Resource,
+  Resource\ApiToken\Entity,
   Tests\Resource\EndpointTestCase,
   Util\Language,
   Util\Util
@@ -36,7 +36,7 @@ class EndpointTest extends EndpointTestCase {
   protected const _SUBJECT_FQCN = Endpoint::class;
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_MODEL_FQCN = Resource::class;
+  protected const _SUBJECT_MODEL_FQCN = Entity::class;
 
   /**
    * {@inheritDoc}

--- a/tests/Resource/ApiToken/EntityTest.php
+++ b/tests/Resource/ApiToken/EntityTest.php
@@ -10,7 +10,7 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Tests\Resource\ApiToken;
 
 use Nexcess\Sdk\ {
-  Resource\ApiToken\Resource,
+  Resource\ApiToken\Entity,
   Resource\ApiToken\ApiTokenException,
   Sandbox\Sandbox,
   Tests\Resource\ModelTestCase,
@@ -20,7 +20,7 @@ use Nexcess\Sdk\ {
 /**
  * Unit test for api token.
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
@@ -36,5 +36,5 @@ class ResourceTest extends ModelTestCase {
     'api-token-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/App/EntityTest.php
+++ b/tests/Resource/App/EntityTest.php
@@ -10,14 +10,14 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Tests\Resource\App;
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource,
+  Resource\App\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for app environments.
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
@@ -32,5 +32,5 @@ class ResourceTest extends ModelTestCase {
   protected const _RESOURCE_TOCOLLAPSEDARRAY = 'app-13.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/Cloud/EntityTest.php
+++ b/tests/Resource/Cloud/EntityTest.php
@@ -10,14 +10,14 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Tests\Resource\Cloud;
 
 use Nexcess\Sdk\ {
-  Resource\Cloud\Resource,
+  Resource\Cloud\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for clouds (virt-cloud hosts).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
@@ -32,5 +32,5 @@ class ResourceTest extends ModelTestCase {
   protected const _RESOURCE_TOCOLLAPSEDARRAY = 'cloud-3.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -11,7 +11,7 @@ namespace Nexcess\Sdk\Tests\Resource\CloudAccount;
 
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Endpoint,
-  Resource\CloudAccount\Resource,
+  Resource\CloudAccount\Entity,
   Tests\Resource\EndpointTestCase,
   Util\Language,
   Util\Util
@@ -36,7 +36,7 @@ class EndpointTest extends EndpointTestCase {
   protected const _SUBJECT_FQCN = Endpoint::class;
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_MODEL_FQCN = Resource::class;
+  protected const _SUBJECT_MODEL_FQCN = Entity::class;
 
   /**
    * {@inheritDoc}

--- a/tests/Resource/CloudAccount/EntityTest.php
+++ b/tests/Resource/CloudAccount/EntityTest.php
@@ -7,30 +7,31 @@
 
 declare(strict_types  = 1);
 
-namespace Nexcess\Sdk\Tests\Resource\Order;
+namespace Nexcess\Sdk\Tests\Resource\CloudAccount;
 
 use Nexcess\Sdk\ {
-  Resource\Order\Resource,
+  Resource\CloudAccount\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for cloud accounts (virtual hosting).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_FROMARRAY = 'order-1.fromArray.json';
+  protected const _RESOURCE_FROMARRAY = 'cloud-account-1.fromArray.json';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOARRAY = 'order-1.toArray-shallow.php';
+  protected const _RESOURCE_TOARRAY = 'cloud-account-1.toArray-shallow.php';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOCOLLAPSEDARRAY = 'order-1.toCollapsedArray.json';
+  protected const _RESOURCE_TOCOLLAPSEDARRAY =
+    'cloud-account-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/CloudAccount/resources/cloud-account-1.toArray-shallow.php
+++ b/tests/Resource/CloudAccount/resources/cloud-account-1.toArray-shallow.php
@@ -1,12 +1,12 @@
 <?php
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource as App,
-  Resource\Cloud\Resource as Cloud,
-  Resource\CloudAccount\Resource as CloudAccount,
+  Resource\App\Entity as App,
+  Resource\Cloud\Entity as Cloud,
+  Resource\CloudAccount\Entity as CloudAccount,
   Resource\Collection,
-  Resource\Order\Resource AS Order,
-  Resource\VirtGuestCloud\Resource as VirtGuestCloud,
+  Resource\Order\Entity AS Order,
+  Resource\VirtGuestCloud\Entity as VirtGuestCloud,
   Util\Util
 };
 

--- a/tests/Resource/CloudServer/EntityTest.php
+++ b/tests/Resource/CloudServer/EntityTest.php
@@ -10,14 +10,14 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Tests\Resource\CloudServer;
 
 use Nexcess\Sdk\ {
-  Resource\CloudServer\Resource,
+  Resource\CloudServer\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for cloud accounts (virtual hosting).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
@@ -33,5 +33,5 @@ class ResourceTest extends ModelTestCase {
     'cloud-server-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/CloudServer/resources/cloud-server-1.toArray-shallow.php
+++ b/tests/Resource/CloudServer/resources/cloud-server-1.toArray-shallow.php
@@ -1,8 +1,8 @@
 <?php
 
 use Nexcess\Sdk\ {
-  Resource\Cloud\Resource as Cloud,
-  Resource\Package\Resource as Package
+  Resource\Cloud\Entity as Cloud,
+  Resource\Package\Entity as Package
 };
 
 return [

--- a/tests/Resource/Invoice/EntityTest.php
+++ b/tests/Resource/Invoice/EntityTest.php
@@ -7,31 +7,31 @@
 
 declare(strict_types  = 1);
 
-namespace Nexcess\Sdk\Tests\Resource\VirtGuestCloud;
+namespace Nexcess\Sdk\Tests\Resource\Invoice;
 
 use Nexcess\Sdk\ {
-  Resource\VirtGuestCloud\Resource,
+  Resource\Invoice\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
- * Unit test for cloud account services.
+ * Unit test for cloud accounts (virtual hosting).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_FROMARRAY = 'service-1.fromArray.json';
+  protected const _RESOURCE_FROMARRAY = 'invoice-1.fromArray.json';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOARRAY = 'service-1.toArray-shallow.php';
+  protected const _RESOURCE_TOARRAY = 'invoice-1.toArray-shallow.json';
 
   /** {@inheritDoc} */
   protected const _RESOURCE_TOCOLLAPSEDARRAY =
-    'service-1.toCollapsedArray.json';
+    'invoice-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/Order/EntityTest.php
+++ b/tests/Resource/Order/EntityTest.php
@@ -7,31 +7,30 @@
 
 declare(strict_types  = 1);
 
-namespace Nexcess\Sdk\Tests\Resource\Invoice;
+namespace Nexcess\Sdk\Tests\Resource\Order;
 
 use Nexcess\Sdk\ {
-  Resource\Invoice\Resource,
+  Resource\Order\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for cloud accounts (virtual hosting).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_FROMARRAY = 'invoice-1.fromArray.json';
+  protected const _RESOURCE_FROMARRAY = 'order-1.fromArray.json';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOARRAY = 'invoice-1.toArray-shallow.json';
+  protected const _RESOURCE_TOARRAY = 'order-1.toArray-shallow.php';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOCOLLAPSEDARRAY =
-    'invoice-1.toCollapsedArray.json';
+  protected const _RESOURCE_TOCOLLAPSEDARRAY = 'order-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/Order/resources/order-1.toArray-shallow.php
+++ b/tests/Resource/Order/resources/order-1.toArray-shallow.php
@@ -1,14 +1,14 @@
 <?php
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource as App,
-  Resource\Cloud\Resource as Cloud,
-  Resource\CloudAccount\Resource as CloudAccount,
+  Resource\App\Entity as App,
+  Resource\Cloud\Entity as Cloud,
+  Resource\CloudAccount\Entity as CloudAccount,
   Resource\Collection,
-  Resource\Invoice\Resource as Invoice,
-  Resource\Package\Resource as Package,
-  Resource\Order\Resource AS Order,
-  Resource\VirtGuestCloud\Resource as VirtGuestCloud
+  Resource\Invoice\Entity as Invoice,
+  Resource\Package\Entity as Package,
+  Resource\Order\Entity as Order,
+  Resource\VirtGuestCloud\Entity as VirtGuestCloud
 };
 
 return [

--- a/tests/Resource/Package/EntityTest.php
+++ b/tests/Resource/Package/EntityTest.php
@@ -10,14 +10,14 @@ declare(strict_types  = 1);
 namespace Nexcess\Sdk\Tests\Resource\Package;
 
 use Nexcess\Sdk\ {
-  Resource\Package\Resource,
+  Resource\Package\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
  * Unit test for cloud accounts (virtual hosting).
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
@@ -33,5 +33,5 @@ class ResourceTest extends ModelTestCase {
     'package-717.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/VirtGuestCloud/EntityTest.php
+++ b/tests/Resource/VirtGuestCloud/EntityTest.php
@@ -7,31 +7,31 @@
 
 declare(strict_types  = 1);
 
-namespace Nexcess\Sdk\Tests\Resource\CloudAccount;
+namespace Nexcess\Sdk\Tests\Resource\VirtGuestCloud;
 
 use Nexcess\Sdk\ {
-  Resource\CloudAccount\Resource,
+  Resource\VirtGuestCloud\Entity,
   Tests\Resource\ModelTestCase
 };
 
 /**
- * Unit test for cloud accounts (virtual hosting).
+ * Unit test for cloud account services.
  */
-class ResourceTest extends ModelTestCase {
+class EntityTest extends ModelTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_FROMARRAY = 'cloud-account-1.fromArray.json';
+  protected const _RESOURCE_FROMARRAY = 'service-1.fromArray.json';
 
   /** {@inheritDoc} */
-  protected const _RESOURCE_TOARRAY = 'cloud-account-1.toArray-shallow.php';
+  protected const _RESOURCE_TOARRAY = 'service-1.toArray-shallow.php';
 
   /** {@inheritDoc} */
   protected const _RESOURCE_TOCOLLAPSEDARRAY =
-    'cloud-account-1.toCollapsedArray.json';
+    'service-1.toCollapsedArray.json';
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_FQCN = Resource::class;
+  protected const _SUBJECT_FQCN = Entity::class;
 }

--- a/tests/Resource/VirtGuestCloud/resources/service-1.toArray-shallow.php
+++ b/tests/Resource/VirtGuestCloud/resources/service-1.toArray-shallow.php
@@ -1,12 +1,12 @@
 <?php
 
 use Nexcess\Sdk\ {
-  Resource\App\Resource as App,
-  Resource\Cloud\Resource as Cloud,
-  Resource\CloudAccount\Resource as CloudAccount,
+  Resource\App\Entity as App,
+  Resource\Cloud\Entity as Cloud,
+  Resource\CloudAccount\Entity as CloudAccount,
   Resource\Collection,
-  Resource\Order\Resource AS Order,
-  Resource\Package\Resource as Package
+  Resource\Order\Entity as Order,
+  Resource\Package\Entity as Package
 };
 
 return [


### PR DESCRIPTION
this is a semantic fix, and also aims to reduce developer+end user confusion by limiting the number of things named "Resource".  An SDK Resource module now looks like this:
```
src/Resource
└──MODULE_NAME
   ├──Endpoint.php
   └──Entity.php
```

all tests updated as well and still pass.