### PR TITLE
Create Dev Account

### DIFF
--- a/src/Resource/CloudAccount/Endpoint.php
+++ b/src/Resource/CloudAccount/Endpoint.php
@@ -85,10 +85,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
       'ref_service_id' => $entity->get('service')->getId(),
       'ref_type' => 'development'
     ] + $data
-      + [
-      'copy_account' => true,
-      'scrub_account' => true,
-    ];
+      + ['copy_account' => true, 'scrub_account' => true];
     $this->_validateParams(__FUNCTION__, $data);
 
     $dev = $this->getModel()->sync(

--- a/src/Resource/CloudAccount/Entity.php
+++ b/src/Resource/CloudAccount/Entity.php
@@ -73,6 +73,24 @@ class Entity extends Model {
   ];
 
   /**
+   * Creates a development-mode account based on this cloud account.
+   *
+   * Note, will fail if this cloud account is not a "primary" account.
+   *
+   * @param array $data Map of settings for new dev account:
+   *  - bool "copy_account" (optional, defaults to true) Copy settings/data?
+   *  - int "package_id" (required) Service package id
+   *  - bool "scrub_account" (optional, defaults to true) Obfuscate PII?
+   *  - string "subdomain" (optional, defaults to "dev.") Dev subdomain
+   * @return Entity The new dev account on success
+   * @throws ResourceException If endpoint not available
+   * @throws ApiException If request fails
+   */
+  public function createDevAccount(array $data) : Entity {
+    return $this->_getEndpoint()->createDevAccount($this, $data);
+  }
+
+  /**
    * Switches PHP version on this cloud account.
    *
    * @param string $version Target PHP version

--- a/src/Resource/CloudAccount/Entity.php
+++ b/src/Resource/CloudAccount/Entity.php
@@ -87,7 +87,10 @@ class Entity extends Model {
    * @throws ApiException If request fails
    */
   public function createDevAccount(array $data) : Entity {
-    return $this->_getEndpoint()->createDevAccount($this, $data);
+    $endpoint = $this->_getEndpoint();
+    $dev = $endpoint->createDevAccount($this, $data);
+    $endpoint->wait();
+    return $dev;
   }
 
   /**

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -97,6 +97,33 @@ abstract class Model implements Modelable {
   }
 
   /**
+   * @see https://php.net/__debugInfo
+   */
+  public function __debugInfo() {
+    return [
+      'module' => $this->moduleName(),
+      'has_endpoint' => isset($this->_endpoint),
+      'values' => array_map(
+        function ($value) {
+          if ($value instanceof Model) {
+            return ['entity' => $value->moduleName(), 'id' => $value->getId()];
+          }
+
+          if ($value instanceof Collection) {
+            return [
+              'collection' => $value->of(),
+              'entities' => $value->getIds()
+            ];
+          }
+
+          return $value;
+        },
+        $this->_values
+      )
+    ];
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function equals(Modelable $other) : bool {

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -97,6 +97,7 @@ abstract class Model implements Modelable {
   }
 
   /**
+   * {@inheritDoc}
    * @see https://php.net/__debugInfo
    */
   public function __debugInfo() {

--- a/src/Resource/ResourceException.php
+++ b/src/Resource/ResourceException.php
@@ -55,6 +55,12 @@ class ResourceException extends Exception {
   /** @var int Attempt to build a model from an invalid value. */
   const UNMODELABLE = 13;
 
+  /** @var int Invalid parameter for an api call. */
+  const WRONG_PARAM = 14;
+
+  /** @var int Missing parameter for an api call. */
+  const MISSING_PARAM = 15;
+
   /** {@inheritDoc} */
   const INFO = [
     self::NO_SUCH_PROPERTY => ['message' => 'resource.no_such_property'],
@@ -73,6 +79,8 @@ class ResourceException extends Exception {
       ['message' => 'resource.no_endpoint_available'],
     self::UNCOLLECTABLE => ['message' => 'resource.uncollectable'],
     self::UNDATETIMEABLE => ['message' => 'resource.undatetimeable'],
-    self::UNMODELABLE => ['message' => 'resource.unmodelable']
+    self::UNMODELABLE => ['message' => 'resource.unmodelable'],
+    self::WRONG_PARAM => ['message' => 'resource.wrong_param'],
+    self::MISSING_PARAM => ['message' => 'resource.missing_param']
   ];
 }

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -32,6 +32,15 @@
         "install_app": "Should the application be installed? Note, this applies only to installable apps.",
         "package_id": "ID of the service package for the new cloud account. @see VirtGuestCloud::list()."
       },
+      "createDevAccount": {
+        "copy_account": "Copy settings/data from parent cloud account?",
+        "domain": "Domain name to use for the new dev account. Note, the parent account domain will be appended: provide ONLY the desired subdomain.",
+        "package_id": "ID of the service package for the new dev account. @see VirtGuestCloud::list().",
+        "ref_cloud_account_id": "ID of the parent cloud account",
+        "ref_service_id": "ID of the parent cloud account's service",
+        "ref_type": "Must be 'development'.",
+        "scrub_account": "Obfuscate personally identifiable information in data copied from parent cloud account?"
+      },
       "setPhpVersion": {
         "version": "Target PHP version to use on cloud account. @see CloudAccount::getAvailablePhpVersions()."
       }

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -9,9 +9,14 @@ declare(strict_types  = 1);
 
 namespace Nexcess\Sdk\Tests\Resource\CloudAccount;
 
+use Throwable;
+use GuzzleHttp\ {
+  Psr7\Response as GuzzleResponse
+};
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Endpoint,
   Resource\CloudAccount\Entity,
+  Resource\ResourceException,
   Tests\Resource\EndpointTestCase,
   Util\Language,
   Util\Util
@@ -21,6 +26,12 @@ class EndpointTest extends EndpointTestCase {
 
   /** {@inheritDoc} */
   protected const _RESOURCE_PATH = __DIR__ . '/resources';
+
+  /** @var string Resource name for new dev account responses. */
+  protected const _RESOURCE_NEW_DEV = 'POST %2Fcloud-account.json';
+
+  /** @var string Resource name for cloud account instance data. */
+  protected const _RESOURCE_CLOUD = 'cloud-account-1.toArray-shallow.php';
 
   /** {@inheritDoc} */
   protected const _RESOURCE_INSTANCES = [
@@ -79,6 +90,59 @@ class EndpointTest extends EndpointTestCase {
         ]
       ],
       [
+        'createDevAccount',
+        [
+          'copy_account' => [
+            Util::TYPE_BOOL,
+            true,
+            'copy_account (boolean): Required. ' .
+              Language::get('resource.CloudAccount.createDevAccount.copy_account')
+          ],
+          'domain' => [
+            Util::TYPE_STRING,
+            true,
+            'domain (string): Required. ' .
+              Language::get('resource.CloudAccount.createDevAccount.domain')
+          ],
+          'package_id' => [
+            Util::TYPE_INT,
+            true,
+            'package_id (integer): Required. ' .
+              Language::get('resource.CloudAccount.createDevAccount.package_id')
+          ],
+          'ref_cloud_account_id' => [
+            Util::TYPE_INT,
+            true,
+            'ref_cloud_account_id (integer): Required. ' .
+              Language::get(
+                'resource.CloudAccount.createDevAccount.ref_cloud_account_id'
+              )
+          ],
+          'ref_service_id' => [
+            Util::TYPE_INT,
+            true,
+            'ref_service_id (integer): Required. ' .
+              Language::get(
+                'resource.CloudAccount.createDevAccount.ref_service_id'
+              )
+          ],
+          'ref_type' => [
+            Util::TYPE_STRING,
+            true,
+            'ref_type (string): Required. ' .
+              Language::get('resource.CloudAccount.createDevAccount.ref_type')
+          ],
+          'scrub_account' => [
+            Util::TYPE_BOOL,
+            true,
+            'scrub_account (boolean): Required. ' .
+              Language::get(
+                'resource.CloudAccount.createDevAccount.scrub_account'
+              )
+          ]
+        ]
+      ],
+      [
         'setPhpVersion',
         [
           'version'=> [
@@ -88,6 +152,90 @@ class EndpointTest extends EndpointTestCase {
               Language::get('resource.CloudAccount.setPhpVersion.version')
           ]
         ]
+      ]
+    ];
+  }
+
+  /**
+   * @covers Endpoint::createDevAccount
+   * @dataProvider createDevAccountProvider
+   *
+   * @param Entity $cloud Parent cloud account
+   * @param array $params Map of test input parameters
+   * @param array|Throwable $expected Expected request payload;
+   *  or an Exception if input is invalid
+   * @param GuzzleResponse|callable|Throwable|null $response Response to queue
+   */
+  public function testCreateDevAccount(
+    Entity $cloud,
+    array $params,
+    $expected,
+    $response = null
+  ) {
+    if ($expected instanceof Throwable) {
+      $this->setExpectedException($expected);
+    }
+
+    $handler = function ($request, $options) use ($expected, $response) {
+      $actual = Util::jsonDecode((string) $request->getBody());
+      foreach ($expected as $param => $expect) {
+        $this->assertArrayHasKey($param, $actual);
+        $this->assertEquals($expect, $actual[$param]);
+      }
+
+      return $response;
+    };
+    $this->_getSandbox(null, $handler)
+      ->play(function ($api, $sandbox) use ($cloud, $params) {
+        $api->getEndpoint(static::_SUBJECT_FQCN)
+          ->createDevAccount($cloud, $params);
+      });
+  }
+
+  /**
+   * @return array[] List of testcases
+   */
+  public function createDevAccountProvider() : array {
+    $fqcn = static::_SUBJECT_MODEL_FQCN;
+    $cloud = Entity::__set_state([
+      '_values' => $this->_getResource(static::_RESOURCE_CLOUD) +
+        ['account_id' => 1]
+    ]);
+    $expected = function ($input) use ($cloud) {
+      return [
+        'domain' => ($input['domain'] ?? 'dev') . ".{$cloud->get('domain')}",
+        'ref_cloud_account_id' => 1,
+        'ref_service_id' => 1,
+        'ref_type' => 'development'
+      ] + $input
+      + ['copy_account' => true, 'scrub_account' => true];
+    };
+    $response = new GuzzleResponse(
+      200,
+      ['Content-type' => 'application/json'],
+      $this->_getResource(static::_RESOURCE_NEW_DEV, false)
+    );
+
+    return [
+      [$cloud, ['package_id' => 1], $expected(['package_id' => 1]), $response],
+      [
+        $cloud,
+        ['package_id' => 1, 'domain' => 'test'],
+        $expected(['package_id' => 1, 'domain' => 'test']),
+        $response
+      ],
+      [
+        $cloud,
+        ['package_id' => 1, 'scrub_account' => false],
+        $expected(['package_id' => 1, 'scrub_account' => false]),
+        $response
+      ],
+
+      [$cloud, [], new ResourceException(ResourceException::MISSING_PARAM)],
+      [
+        $cloud,
+        ['package_id' => 'foo'],
+        new ResourceException(ResourceException::WRONG_PARAM)
       ]
     ];
   }

--- a/tests/Resource/CloudAccount/resources/POST %2Fcloud-account.json
+++ b/tests/Resource/CloudAccount/resources/POST %2Fcloud-account.json
@@ -1,0 +1,187 @@
+{
+	"account_id": 1,
+	"host_id": 1,
+	"domain": "dev.cloudy.example.com",
+	"status": "used",
+	"deploy_date": 1539284428,
+	"deploy_complete_date": 0,
+	"project_id": 1,
+	"parent_account_id": 0,
+	"reference_account_id": 1,
+	"ssl_cert_id": 0,
+	"state": "creating",
+	"id": 1,
+	"identity": "dev.cloudy.example.com",
+	"is_real": true,
+	"meta": {
+		"scope": "virt-guest-cloudaccount"
+	},
+	"ip": "203.0.113.1",
+	"ipv4": "203.0.113.1",
+	"is_dev_account": true,
+	"temp_domain": "1234abcd.nxcli.net",
+	"cloudhost_hostname": "cloudhost-1234abcd.us-midwest-1.nxcli.net",
+	"unix_username": "1234abcd",
+	"app": {
+		"id": 1,
+		"identity": "Example",
+		"is_real": true,
+		"meta": {
+			"scope": "app-app"
+		},
+		"type": "example",
+		"status": "active",
+		"name": "Example",
+		"version": "1",
+		"is_wordpress_based": false,
+		"is_installable": true
+	},
+	"service": {
+		"id": 2,
+		"identity": "dev.cloudy.example.com - nc.small-dev",
+		"is_real": true,
+		"meta": {
+			"scope": "service"
+		},
+		"type": "virt-guest-cloud",
+		"status": "enabled",
+		"description": "nc.small-dev",
+		"nickname": "",
+		"next_bill_date": 1541912400,
+		"host": "dev.cloudy.example.com",
+		"cloud_account": {
+			"account_id": 2,
+			"host_id": 1,
+			"domain": "dev.cloudy.example.com",
+			"status": "used",
+			"deploy_date": 1539284428,
+			"deploy_complete_date": 0,
+			"project_id": 1,
+			"parent_account_id": 0,
+			"reference_account_id": 1,
+			"ssl_cert_id": 0,
+			"state": "creating",
+			"id": 2,
+			"identity": "dev.cloudy.example.com",
+			"is_real": true,
+			"meta": {
+				"scope": "virt-guest-cloudaccount"
+			},
+			"ip": "203.0.113.1",
+			"ipv4": "203.0.113.1",
+			"is_dev_account": true,
+			"temp_domain": "abcd1234.nxcli.net",
+			"cloudhost_hostname": "cloudhost-abcd1234.us-midwest-1.nxcli.net",
+			"unix_username": "abcd1234",
+			"app": {
+				"id": 1,
+				"identity": "Example",
+				"is_real": true,
+				"meta": {
+					"scope": "app-app"
+				},
+				"type": "example",
+				"status": "active",
+				"name": "Example",
+				"version": "1",
+				"is_wordpress_based": false,
+				"is_installable": true
+			},
+			"environment": {
+				"software": {
+					"php": {
+						"version": "7.1",
+						"path": "\/opt\/remi\/php71",
+						"cli": "\/opt\/remi\/php71\/root\/usr\/bin\/php"
+					},
+					"redis": {
+						"host": "",
+						"port": "",
+						"socket": "\/var\/run\/redis-multi-a5fbe924.redis\/redis.sock",
+						"version": "3.2"
+					}
+				},
+				"options": {
+					"nxcache_nocache": false,
+					"nxcache_varnish": false,
+					"nxcache_varnish_static": false,
+					"nxcache_varnish_ttl": 120,
+					"autoscale_enabled": true
+				},
+				"access": []
+			}
+		},
+		"environment_type": "development",
+		"isolation_zone": {
+			"id": 1,
+			"identity": "Southfield, MI",
+			"is_real": true,
+			"meta": {
+				"scope": "isolation-zone"
+			}
+		},
+		"location": {
+			"id": 1,
+			"identity": "us-midwest-1",
+			"is_real": true,
+			"meta": {
+				"scope": "virt-cloud"
+			},
+			"type": "openstack",
+			"status": "active",
+			"location": "Southfield, MI",
+			"location_code": "us-midwest-1",
+			"country": "US"
+		},
+		"order": {
+			"id": 1,
+			"identity": "(1) Alice McAllison",
+			"is_real": true,
+			"meta": {
+				"scope": "order"
+			},
+			"type": "virt-guest-cloud",
+			"status": "allocated",
+			"months": 1,
+			"location": {
+				"id": 1,
+				"identity": "us-midwest-1",
+				"is_real": true,
+				"meta": {
+					"scope": "virt-cloud"
+				},
+				"type": "openstack",
+				"status": "active",
+				"location": "Southfield, MI",
+				"location_code": "us-midwest-1",
+				"country": "US"
+			}
+		},
+		"dev_account_count": 0,
+		"state": "creating",
+		"child_cloud_accounts": []
+	},
+	"environment": {
+		"software": {
+			"php": {
+				"version": "7.1",
+				"path": "\/opt\/remi\/php71",
+				"cli": "\/opt\/remi\/php71\/root\/usr\/bin\/php"
+			},
+			"redis": {
+				"host": "",
+				"port": "",
+				"socket": "\/var\/run\/redis-multi-a5fbe924.redis\/redis.sock",
+				"version": "3.2"
+			}
+		},
+		"options": {
+			"nxcache_nocache": false,
+			"nxcache_varnish": false,
+			"nxcache_varnish_static": false,
+			"nxcache_varnish_ttl": 120,
+			"autoscale_enabled": true
+		},
+		"access": []
+	}
+}


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-10452
```php
$client->getEndpoint('CloudAccount')
  ->retrieve($cloud_id)
  ->createDevAccount([
    'package_id' => $package_id,
    'domain' => 'test'
  ]);
```
```php
$client->getEndpoint('CloudAccount')->getParams('createDevAccount');
/*
[
  'copy_account' => [
    'boolean',
    true,
    'copy_account (boolean): Required. Copy settings/data from parent cloud account?'
  ],
  'domain' => [
    'string',
    true,
    'domain (string): Required. Domain name to use for the new dev account. Note, the parent account domain will be appended: provide ONLY the desired subdomain.'
  ],
  'package_id' => [
    'integer',
    true,
    'package_id (integer): Required. ID of the service package for the new dev account. @see VirtGuestCloud::list().'
  ],
  'ref_cloud_account_id' => [
    'integer',
    true,
    'ref_cloud_account_id (integer): Required. ID of the parent cloud account'
  ],
  'ref_service_id' => [
    'integer',
    true,
    "ref_service_id (integer): Required. ID of the parent cloud account's service"
  ],
  'ref_type' => [
    'string',
    true,
    "ref_type (string): Required. Must be 'development'."
  ],
  'scrub_account' => [
    'boolean',
    true,
    'scrub_account (boolean): Required. Obfuscate personally identifiable information in data copied from parent cloud account?'
  ]
]
*/
```
From the user's perspective, only the `package_id` is strictly required. `domain` will default to `"dev.<PARENT_CLOUD_DOMAIN>"` and `copy_account` and `scrub_account` will default to `true`.  Other params are filled in from the parent cloud account (overwriting any manual inputs).