### PR TITLE
Don't Index by Id

### DIFF
--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -205,7 +205,7 @@ class Collection implements Collector {
    */
   public function remove($model_or_id) : Model {
     foreach ($this->_models as $i => $model) {
-      if ($model->equals($target) || $model->getId() === $target) {
+      if ($model->equals($model_or_id) || $model->getId() === $model_or_id) {
         unset($this->_models[$i]);
         return $model;
       }
@@ -213,7 +213,7 @@ class Collection implements Collector {
 
     throw new ModelException(
       ModelException::MODEL_NOT_FOUND,
-      ['model' => $this->_of, 'id' => $id]
+      ['model' => $this->_of, 'id' => $model_or_id]
     );
   }
 

--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -66,7 +66,7 @@ class Collection implements Collector {
       );
     }
 
-    $this->_models[$model->getId()] = $model;
+    $this->_models[] = $model;
 
     return $this;
   }
@@ -147,11 +147,8 @@ class Collection implements Collector {
   /**
    * {@inheritDoc}
    */
-  public function find($criteria) {
-    throw new SdkException(
-      SdkException::NOT_IMPLEMENTED,
-      ['method' => __METHOD__]
-    );
+  public function find($criteria) : ?Model {
+    return $this->filter($criteria)->current();
   }
 
   /**
@@ -207,20 +204,17 @@ class Collection implements Collector {
    * {@inheritDoc}
    */
   public function remove($model_or_id) : Model {
-    $id = $model_or_id;
-    if ($model_or_id instanceof $this->_of) {
-      $id = $model_or_id->get('id');
-    }
-    if (! is_int($id) || ! isset($this->_models[$id])) {
-      throw new ModelException(
-        ModelException::MODEL_NOT_FOUND,
-        ['model' => $this->_of, 'id' => $id]
-      );
+    foreach ($this->_models as $i => $model) {
+      if ($model->equals($target) || $model->getId() === $target) {
+        unset($this->_models[$i]);
+        return $model;
+      }
     }
 
-    $model = $this->_models[$id];
-    unset($this->_models[$id]);
-    return $model;
+    throw new ModelException(
+      ModelException::MODEL_NOT_FOUND,
+      ['model' => $this->_of, 'id' => $id]
+    );
   }
 
   /**

--- a/src/Resource/Collector.php
+++ b/src/Resource/Collector.php
@@ -87,7 +87,7 @@ interface Collector extends Countable, Iterator, JsonSerializable {
    * @return Model|null A matching item, if any found; null otherwise
    * @throws SdkException If criteria callback errors
    */
-  public function find($criteria);
+  public function find($criteria) : ?Model;
 
   /**
    * Gets list of ids of items in this collection.

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -177,7 +177,7 @@ abstract class Model implements Modelable {
    * {@inheritDoc}
    */
   public function getId() : ?int {
-    return $this->get('id');
+    return $this->_values[static::_PROPERTY_ALIASES['id'] ?? 'id'] ?? null;
   }
 
   /**

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -37,9 +37,6 @@ class EndpointTest extends EndpointTestCase {
   /** @var string Resource name for cloud account instance data. */
   protected const _RESOURCE_CLOUD = 'cloud-account-1.toArray-shallow.php';
 
-  /** @var string Resource name for cloud account #1 json payload. */
-  protected const _RESOURCE_GET_1 = 'GET %2Fcloud-account%2F1.json';
-
   /** {@inheritDoc} */
   protected const _RESOURCE_INSTANCES = [
     'cloud-account-1.fromArray.json' => 'cloud-account-1.toArray-shallow.php'
@@ -215,7 +212,7 @@ class EndpointTest extends EndpointTestCase {
 
       $this->assertArrayHasKey('_action', $actual);
       $this->assertEquals($actual['_action'], 'purge-cache');
-    
+
       return new GuzzleResponse(
         200,
         ['Content-type' => 'application/json'],


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12045

Models don't always have an id (e.g., stubs/unsaved models, "special case" models like Backups).
Indexing by id also creates a bug where different instances with the same id would silently overwrite each other.