### PR TITLE
Promised

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -61,6 +61,9 @@ class ApiException extends Exception {
   /** @var int Create request failed. */
   const CREATE_FAILED = 16;
 
+  /** @var int Tried to decode an invalid or not-json response. */
+  const NOT_DECODABLE = 17;
+
   /** {@inheritDoc} */
   const INFO = [
     self::CANNOT_CONNECT => ['message' => 'api.cannot_connect'],
@@ -78,6 +81,7 @@ class ApiException extends Exception {
     self::NO_SUCH_ENDPOINT => ['message' => 'api.no_such_endpoint'],
     self::GOT_MALFORMED_LIST => ['message' => 'api.got_malformed_list'],
     self::NOT_CREATABLE => ['message' => 'api.not_creatable'],
-    self::CREATE_FAILED => ['message' => 'api.create_failed']
+    self::CREATE_FAILED => ['message' => 'api.create_failed'],
+    self::NOT_DECODABLE => ['message' => 'api.not_decodable']
   ];
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -290,15 +290,6 @@ class Client {
         ($params['headers'] ?? []) + $this->_getDefaultHeaders();
 
       return $this->_client->request($method, $endpoint, $params);
-
-      $guzzle_response = $this->_client->request($method, $endpoint, $params);
-      $content_type = $guzzle_response->getHeader('Content-type');
-      $body = (string) $guzzle_response->getBody();
-      $body = ($body === 'null') ? '[]' : $body;
-
-      return (reset($content_type) === 'application/json') ?
-        Util::jsonDecode($body) :
-        ['response' => $body];
     } catch (ConnectException $e) {
       throw new ApiException(ApiException::CANNOT_CONNECT, $e);
     } catch (ClientException $e) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,8 @@ use GuzzleHttp\ {
   Exception\RequestException,
   Exception\ServerException,
   HandlerStack as GuzzleHandlerStack,
-  Middleware as GuzzleMiddleware
+  Middleware as GuzzleMiddleware,
+  Psr7\Response as GuzzleResponse
 };
 
 use function GuzzleHttp\default_user_agent as guzzle_user_agent;
@@ -28,13 +29,14 @@ use Nexcess\Sdk\ {
   Resource\Creatable,
   Resource\Modelable as Model,
   Resource\Readable as Endpoint,
-  Resource\Response,
   Resource\Updatable,
   SdkException,
   Util\Config,
   Util\Language,
   Util\Util
 };
+
+use Psr7\Http\Message\ResponseInterface as Response;
 
 /**
  * API client for nexcess.net / thermo.io
@@ -274,7 +276,7 @@ class Client {
    * @param string $method The http method to use
    * @param string $endpoint The API endpoint to request
    * @param array $params Http client parameters
-   * @return array Response data
+   * @return GuzzleResponse Api response
    * @throws ApiException On http error (4xx, 5xx, network issues, etc.)
    * @throws SdkException On any other error
    */
@@ -282,10 +284,12 @@ class Client {
     string $method,
     string $endpoint,
     array $params = []
-  ) : array {
+  ) : GuzzleResponse {
     try {
       $params['headers'] =
         ($params['headers'] ?? []) + $this->_getDefaultHeaders();
+
+      return $this->_client->request($method, $endpoint, $params);
 
       $guzzle_response = $this->_client->request($method, $endpoint, $params);
       $content_type = $guzzle_response->getHeader('Content-type');

--- a/src/Resource/CanDelete.php
+++ b/src/Resource/CanDelete.php
@@ -12,7 +12,8 @@ namespace Nexcess\Sdk\Resource;
 use Nexcess\Sdk\ {
   ApiException,
   Resource\Deletable,
-  Resource\Model
+  Resource\Model,
+  Resource\PromisedResource
 };
 
 /**
@@ -40,8 +41,9 @@ trait CanDelete {
       );
     }
 
-    $this->_client->request('DELETE', static::_URI . "/{$id}");
-    $this->_wait($this->_waitUntilDelete($model));
+    $this->_delete(static::_URI . "/{$id}");
+    return $this->_buildPromise($model)
+      ->waitUntil($this->_waitUntilDelete());
 
     return $this;
   }
@@ -49,13 +51,12 @@ trait CanDelete {
   /**
    * Checks for a DELETE to finish and then syncs the associated Model.
    *
-   * @param Model $model
-   * @return callable @see wait() $until
+   * @return callable @see PromisedResource::waitUntil() $done
    */
-  protected function _waitUntilDelete(Model $model) : callable {
-    return function ($endpoint) use ($model) {
+  protected function _waitUntilDelete() : callable {
+    return function ($model) {
       try {
-        $endpoint->retrieve($model->getId());
+        $this->retrieve($model->getId());
       } catch (ApiException $e) {
         if ($e->getCode() === ApiException::NOT_FOUND) {
           $model->unset('id');

--- a/src/Resource/CanDelete.php
+++ b/src/Resource/CanDelete.php
@@ -25,7 +25,7 @@ trait CanDelete {
   /**
    * {@inheritDoc}
    */
-  public function delete($model_or_id) : Deletable {
+  public function delete($model_or_id) : PromisedResource {
     $model = is_int($model_or_id) ?
       $this->getModel($model_or_id) :
       $model_or_id;
@@ -44,8 +44,6 @@ trait CanDelete {
     $this->_delete(static::_URI . "/{$id}");
     return $this->_buildPromise($model)
       ->waitUntil($this->_waitUntilDelete());
-
-    return $this;
   }
 
   /**

--- a/src/Resource/CanUpdate.php
+++ b/src/Resource/CanUpdate.php
@@ -12,6 +12,7 @@ namespace Nexcess\Sdk\Resource;
 use Nexcess\Sdk\ {
   ApiException,
   Resource\Modelable,
+  Resource\PromisedResource,
   Resource\Updatable
 };
 
@@ -24,7 +25,10 @@ trait CanUpdate {
   /**
    * {@inheritDoc}
    */
-  public function update(Modelable $model, array $data = []) : Updatable {
+  public function update(
+    Modelable $model,
+    array $data = []
+  ) : PromisedResource {
     $this->_checkModelType($model);
 
     $id = $model->getId();
@@ -52,12 +56,11 @@ trait CanUpdate {
 
     if (! empty($update)) {
       $model->sync(
-        $this->_client
-          ->request('PATCH', static::_URI . "/{$id}/edit", $update),
+        $this->_patch(static::_URI . "/{$id}", $update),
         true
       );
     }
-    $this->_wait(null);
-    return $this;
+
+    return $this->_buildPromise($model);
   }
 }

--- a/src/Resource/CloudAccount/Entity.php
+++ b/src/Resource/CloudAccount/Entity.php
@@ -87,16 +87,15 @@ class Entity extends Model {
    * @throws ApiException If request fails
    */
   public function createDevAccount(array $data) : Entity {
-    $endpoint = $this->_getEndpoint();
-    $dev = $endpoint->createDevAccount($this, $data);
-    $endpoint->wait();
-    return $dev;
+    return $this->_getEndpoint()->createDevAccount($this, $data)->wait();
   }
 
   /**
    * Gets php versions available for this cloud account to use.
    *
    * @return string[] List of available php major.minor versions
+   * @throws ResourceException If endpoint not available
+   * @throws ApiException If request fails
    */
   public function getAvailablePhpVersions() : array {
     return $this->_getEndpoint()->getAvailablePhpVersions($this);
@@ -111,8 +110,7 @@ class Entity extends Model {
    * @throws ApiException If request fails
    */
   public function setPhpVersion(string $version) : Entity {
-    $this->_getEndpoint()->setPhpVersion($this, $version)->wait();
-    return $this;
+    return $this->_getEndpoint()->setPhpVersion($this, $version)->wait();
   }
 
   /**
@@ -123,8 +121,7 @@ class Entity extends Model {
    * @throws ApiException If request fails
    */
   public function clearNginxCache() : Entity {
-    $this->_getEndpoint()->clearNginxCache($this);
-    return $this;
+    return $this->_getEndpoint()->clearNginxCache($this)->wait();
   }
 
   /**
@@ -162,5 +159,4 @@ class Entity extends Model {
   public function deleteBackup(string $filename) {
     $this->_getEndpoint()->downloadBackup($this, $filename);
   }
-  
 }

--- a/src/Resource/Deletable.php
+++ b/src/Resource/Deletable.php
@@ -11,6 +11,7 @@ namespace Nexcess\Sdk\Resource;
 
 use Nexcess\Sdk\ {
   Resource\Modelable as Model,
+  Resource\PromisedResource,
   Resource\Readable
 };
 
@@ -23,8 +24,8 @@ interface Deletable extends Readable {
    * Deletes an existing item.
    *
    * @param Model|int $model_or_id Model or item id to delete
-   * @return Deletable $this
+   * @return PromisedResource A promise wrapping the deleted model
    * @throws ApiException If request fails
    */
-  public function delete($model_or_id) : Deletable;
+  public function delete($model_or_id) : PromisedResource;
 }

--- a/src/Resource/Endpoint.php
+++ b/src/Resource/Endpoint.php
@@ -163,7 +163,7 @@ abstract class Endpoint implements Readable {
   public function sync(Model $model) : Model {
     $id = $model->getId();
     $this->_retrieved[$id] = Util::decodeResponse(
-      $this->_client->request('GET', static::_URI . "/{$id}")
+      $this->_get(static::_URI . "/{$id}")
     );
 
     $model->sync($this->_retrieved[$id]);

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -104,8 +104,15 @@ abstract class Model implements Modelable {
    * @see https://php.net/__debugInfo
    */
   public function __debugInfo() {
+    $module = $this->moduleName();
+    $name = basename(__CLASS__);
+    if ($name === 'Entity') {
+      $name = $module;
+    }
+
     return [
-      'module' => $this->moduleName(),
+      'entity' => $name,
+      'module' => $module,
       'has_endpoint' => isset($this->_endpoint),
       'values' => array_map(
         function ($value) {
@@ -296,7 +303,9 @@ abstract class Model implements Modelable {
       $prior = $this->_values;
 
       if ($hard) {
+        // clear state
         $this->_values = array_fill_keys(self::_PROPERTY_NAMES, null);
+        $this->_hydrated = false;
       }
 
       foreach ($data as $key => $value) {

--- a/src/Resource/PromisedResource.php
+++ b/src/Resource/PromisedResource.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package Nexcess-SDK
+ * @license https://opensource.org/licenses/MIT
+ * @copyright 2018 Nexcess.net, LLC
+ */
+
+declare(strict_types  = 1);
+
+namespace Nexcess\Sdk\Resource;
+
+use GuzzleHttp\Promise\Promise;
+
+use Nexcess\Sdk\ {
+  ApiException,
+  Resource\Modelable,
+  Resource\ResourceException,
+  SdkException,
+  Util\Config
+};
+
+class PromisedResource extends Promise {
+
+  /** @var int Default wait interval. */
+  protected const _DEFAULT_WAIT_INTERVAL = 1;
+
+  /** @var int Default timeout before waiting fails. */
+  protected const _DEFAULT_WAIT_TIMEOUT = 30;
+
+  /** @var int Time to abort. */
+  protected $_deadline;
+
+  /** @var callable The polling condition. */
+  protected $_done;
+
+  /** @var Modelable The resource to resolve to. */
+  protected $_resource;
+
+  /** @var int Maximum wait time. */
+  protected $_timeout;
+
+  /**
+   * @param Config $config Config instance
+   * @param Modelable $model The resource to resolve to
+   */
+  public function __construct(Config $config, Modelable $model) {
+    $this->_config = $config;
+    $this->_resource = $model;
+    parent::__construct([$this, '_wait'], null);
+  }
+
+  /**
+   * Sets the callback to determine when we're ready to resolve.
+   *
+   * The callback signature is like
+   *  bool $done(Modelable $model) Returns true when done waiting for $model
+   *
+   * @param callable $done Waiting callback
+   */
+  public function waitUntil(callable $done) : PromisedResource {
+    $this->_done = $done;
+    return $this;
+  }
+
+  /**
+   * Waits until we're ready, then resolves or rejects.
+   */
+  protected function _wait() {
+    if ($this->_done === null) {
+      $this->resolve($this->_resource);
+      return;
+    }
+
+    try {
+      $this->_waitPrep();
+
+      while (($this->_done)($this->_resource) !== true) {
+        $this->_tick();
+      }
+
+      $this->resolve($this->_resource);
+    } catch (Throwable $e) {
+      if (! $e instanceof ApiException && ! $e instanceof SdkException) {
+        $e = new SdkException(SdkException::CALLBACK_ERROR, $e);
+      }
+
+      $this->reject($e);
+    }
+  }
+
+  /**
+   * Get ready to wait.
+   */
+  protected function _waitPrep() {
+    $this->_tick = $this->_config->get('wait.tick_function');
+    $this->_interval = $this->_config->get('wait.interval') ??
+      self::_DEFAULT_WAIT_INTERVAL;
+    $this->_timeout = $this->_config->get('wait.timeout') ??
+      self::_DEFAULT_WAIT_TIMEOUT;
+    $this->_deadline = time() + $this->_timeout;
+  }
+
+  /**
+   * Waits for next poll, invoking the registered tick function if one exists.
+   */
+  protected function _tick() {
+    if ($this->_tick) {
+      ($this->_tick)();
+    }
+
+    if (time() > $this->_deadline) {
+      throw new ResourceException(
+        ResourceException::WAIT_TIMEOUT_EXCEEDED,
+        ['timeout' => $this->_timeout]
+      );
+    }
+
+    sleep($this->_interval);
+  }
+}

--- a/src/Resource/Readable.php
+++ b/src/Resource/Readable.php
@@ -36,6 +36,14 @@ interface Readable {
   public function getModel(string $name = null) : Model;
 
   /**
+   * Gets a list of parameters and their descriptions for an action.
+   *
+   * @param string $action The subject action
+   * @return array A parameter name: [type, required, description] map
+   */
+  public function getParams(string $action) : array;
+
+  /**
    * Fetches a paginated list of items from the API.
    *
    * @param array $filter Pagination and Model-specific filter options
@@ -54,49 +62,14 @@ interface Readable {
   public function retrieve(int $id) : Model;
 
   /**
-   * Syncs a Model with most recently fetched data from the API,
-   * or re-fetches the item from the API.
+   * Re-fetches a resource from the API.
    *
    * Note, this can OVERWRITE the model's state with the response from the API;
    * but it WILL NOT UPDATE the API with the model's current state.
    * To save changes to an updatable model, @see Updatable::update
    *
-   * @param bool $hard Force hard sync with API?
+   * @param Model The Model to sync
    * @return Model The sync'd model
    */
-  public function sync(Model $model, bool $hard = false) : Model;
-
-  /**
-   * Blocks until callback returns true.
-   *
-   * Some actions are queued by the API,
-   * and so may not be complete at the time the API response is received.
-   * This method is used to wait for a queued action to complete
-   * (though it is possible, of course, to use it to wait for anything).
-   *
-   * @example <?php
-   *  // suppose this code may experience a race condition,
-   *  //  where the $model object is in the wrong state for the second call:
-   *  $endpoint->someQueuedAction($model)
-   *    ->someOtherAction($model);
-   *
-   *  // to prevent this, wait() for the queued action to complete first:
-   *  $endpoint->someQueuedAction($model)
-   *    ->wait()
-   *    ->someOtherAction($model);
-   *
-   * The callback signature is like
-   *  bool $until(Readable $endpoint) Returns true when done waiting
-   *
-   * If no callback is provided,
-   * this will use a callback provided by the most recent action,
-   * or return immediately if none exists.
-   *
-   * @param callable|null $until The callback to wait for
-   * @param array $opts Wait interval/timeout options
-   * @return Readable $this
-   * @throws ApiException If callback throws an ApiException
-   * @throws SdkException If callback throws any other exception
-   */
-  public function wait(callable $until = null, array $opts = []) : Readable;
+  public function sync(Model $model) : Model;
 }

--- a/src/Resource/Service/Endpoint.php
+++ b/src/Resource/Service/Endpoint.php
@@ -111,7 +111,7 @@ abstract class Endpoint extends BaseEndpoint {
 
     $survey['service_id'] = $service->getId();
     return $this->getModel(ServiceCancellation::class)->sync(
-      $this->_client->request('POST', static::_URI_CANCEL, $survey)
+      $this->_post(static::_URI_CANCEL, $survey)
     );
   }
 

--- a/src/Resource/Updatable.php
+++ b/src/Resource/Updatable.php
@@ -11,6 +11,7 @@ namespace Nexcess\Sdk\Resource;
 
 use Nexcess\Sdk\ {
   Resource\Modelable as Model,
+  Resource\PromisedResource,
   Resource\Readable
 };
 
@@ -28,8 +29,8 @@ interface Updatable extends Readable {
    *
    * @param int $id Item id
    * @param array|null $data Map of properties:values to set before update
-   * @return Updatable $this
+   * @return PromisedResource A promise wrapping the updated resource
    * @throws ApiException If request fails
    */
-  public function update(Model $model, array $data = []) : Updatable;
+  public function update(Model $model, array $data = []) : PromisedResource;
 }

--- a/src/Resource/VirtGuestCloud/Endpoint.php
+++ b/src/Resource/VirtGuestCloud/Endpoint.php
@@ -11,7 +11,8 @@ namespace Nexcess\Sdk\Resource\VirtGuestCloud;
 
 use Nexcess\Sdk\ {
   Resource\Service\Endpoint as ServiceEndpoint,
-  Resource\VirtGuestCloud\Entity
+  Resource\VirtGuestCloud\Entity,
+  Util\Util
 };
 
 /**
@@ -35,9 +36,9 @@ class Endpoint extends ServiceEndpoint {
    * @return string[] List of available php major.minor versions
    */
   public function getAvailablePhpVersions(Entity $entity) : array {
-    $this->_wait(null);
-    return $this->_client
-      ->request('GET', static::_URI . "/{$entity->getId()}/get-php-versions");
+    return Util::decodeResponse(
+      $this->_get(static::_URI . "/{$entity->getId()}/get-php-versions")
+    );
   }
 
   /**
@@ -45,12 +46,14 @@ class Endpoint extends ServiceEndpoint {
    *
    * @param Entity $entity Service instance
    * @param string $version Desired PHP version
-   * @return Endpoint $this
+   * @return PromisedResource Promise that resolves to updated entity
    * @throws ApiException If request fails
    */
-  public function setPhpVersion(Entity $entity, string $version) : Endpoint {
-    $this->_wait(null);
+  public function setPhpVersion(
+    Entity $entity,
+    string $version
+  ) : PromisedResource {
     $entity->get('cloud_account')->setPhpVersion($version);
-    return $this;
+    return $this->_buildPromise($entity);
   }
 }

--- a/src/Resource/VirtGuestCloud/Entity.php
+++ b/src/Resource/VirtGuestCloud/Entity.php
@@ -112,9 +112,8 @@ class Entity extends Service {
    * @return Entity $this
    * @throws ApiException If request fails
    */
-  public function setPhpVersion(Entity $entity, string $version) : Endpoint {
-    $this->_getEndpoint()->setPhpVersion($this, $version)->wait();
-    return $this;
+  public function setPhpVersion(Entity $entity, string $version) : Entity {
+    return $this->_getEndpoint()->setPhpVersion($this, $version)->wait();
   }
 
   /**

--- a/tests/Resource/CloudAccount/EntityTest.php
+++ b/tests/Resource/CloudAccount/EntityTest.php
@@ -12,7 +12,9 @@ namespace Nexcess\Sdk\Tests\Resource\CloudAccount;
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Endpoint,
   Resource\CloudAccount\Entity,
-  Tests\Resource\ModelTestCase
+  Resource\PromisedResource,
+  Tests\Resource\ModelTestCase,
+  Util\Config
 };
 
 /**
@@ -65,7 +67,7 @@ class EntityTest extends ModelTestCase {
     $endpoint->expects($this->once())
       ->method('setPhpVersion')
       ->with($this->equalTo($entity), $this->equalTo('7.2'))
-      ->willReturn($endpoint);
+      ->willReturn(new PromisedResource(new Config(), $entity));
 
     $entity->setApiEndpoint($endpoint);
 


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12036
fixes https://nexcess.atlassian.net/browse/NSD-12261

extra scrutiny please
also please lmk if you have questions or feel something is missing from the imlementation

Note, Promise ≠ async
=====================

Promises here should be thought of as a queuing system for callbacks, nothing more.

how things work now:
- Client->request() returns a raw Guzzle Response object
- Endpoint->whateverAction() can use Util::decodeResponse() to get the payload as an array, which can then be sync'd to an $entity, etc.
- Endpoint actions **no longer return $this**:
  - where raw data is expected (e.g., getAvailablePhpVersions() returns an array), continue to do so
  - where an Entity should be returned, use Endpoint->_buildPromise($entity) instead.
  - where an Entity should be returned, but the action may not have yet completed, set up polling by adding a ->waitUntil($callback). This does not poll immediately: it will only poll if the end user calls ->wait() on the promise.
  - Most endpoint actions will need to change return type hints
- "proxied" actions on Entities **no longer** wait() on the endpoint and the return $this:
  - instead, `return $this->_getEndpoint()->doWhatever($this)->wait();`
- regardless of whether polling is set up, end users can:
  - call then() to add a callback, to be invoked after any polling finishes
  - call wait() to kick off any polling and/or then() callbacks and "unwrap" the $entity

updating wiki.