### PR TITLE
Testing Promises

### DIFF
--- a/src/Resource/CloudAccount/Endpoint.php
+++ b/src/Resource/CloudAccount/Endpoint.php
@@ -137,7 +137,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
    * Overridden to handle both Entity and secondary Entities (Backup).
    */
   public function sync(Modelable $model) : Modelable {
-    if ($model instanceof Backup) {
+    if ($model instanceof Backup && $model->isReal()) {
       return $model->sync(
         $this->getBackup($model->getCloudAccount(), $model->get('filename'))
           ->toArray()

--- a/src/Resource/Endpoint.php
+++ b/src/Resource/Endpoint.php
@@ -145,6 +145,13 @@ abstract class Endpoint implements Readable {
    * {@inheritDoc}
    */
   public function sync(Modelable $model) : Modelable {
+    if (! $model->isReal()) {
+      throw new ResourceException(
+        ResourceException::UNSYNCABLE,
+        ['model' => get_class($model)]
+      );
+    }
+
     $id = $model->getId();
     $this->_retrieved[$id] = Util::decodeResponse(
       $this->_client->get(static::_URI . "/{$id}")

--- a/src/Resource/Model.php
+++ b/src/Resource/Model.php
@@ -105,7 +105,7 @@ abstract class Model implements Modelable {
    */
   public function __debugInfo() {
     $module = $this->moduleName();
-    $name = basename(__CLASS__);
+    $name = basename(strtr(static::class, ['\\' => '/']));
     if ($name === 'Entity') {
       $name = $module;
     }

--- a/src/Resource/ResourceException.php
+++ b/src/Resource/ResourceException.php
@@ -64,6 +64,9 @@ class ResourceException extends Exception {
   /** @var int Data can't be collapsed. */
   const UNCOLLAPSABLE = 16;
 
+  /** @var int Can't sync a model that isn't real. */
+  const UNSYNCABLE = 17;
+
   /** {@inheritDoc} */
   const INFO = [
     self::NO_SUCH_PROPERTY => ['message' => 'resource.no_such_property'],
@@ -85,6 +88,7 @@ class ResourceException extends Exception {
     self::UNMODELABLE => ['message' => 'resource.unmodelable'],
     self::WRONG_PARAM => ['message' => 'resource.wrong_param'],
     self::MISSING_PARAM => ['message' => 'resource.missing_param'],
-    self::UNCOLLAPSABLE => ['message' => 'resource.uncollapsable']
+    self::UNCOLLAPSABLE => ['message' => 'resource.uncollapsable'],
+    self::UNSYNCABLE => ['message' => 'resource.unsyncable']
   ];
 }

--- a/src/Sandbox/Sandbox.php
+++ b/src/Sandbox/Sandbox.php
@@ -99,7 +99,6 @@ class Sandbox {
    */
   public function handle(Request $request, array $options = []) : Promise {
     $request_key = "{$request->getMethod()} {$request->getUri()->getPath()}";
-
     $response = $this->_getResponseFor($request_key) ??
       $this->_handler ??
       new ServerException(

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -80,10 +80,11 @@
     "sync_failed": "Failed to sync {model}:{id} with API response: {__rootMessage__}",
     "wait_timeout_exceeded": "Wait timeout exceeded (waited {timeout} seconds)",
     "wrong_model_for_collection": "Cannot add {model} to collection of '{collection}' models",
-    "uncollapsable": "cannot collapse property '{property}': {type}",
-    "uncollectable": "cannot build a collection of {of} using {type}: {data}",
-    "undatetimeable": "cannot build datetime using {type}: {datetime}",
-    "unmodelable": "cannot build {model} model using {type}: {data}",
+    "uncollapsable": "Cannot collapse property '{property}': {type}",
+    "uncollectable": "Cannot build a collection of {of} using {type}: {data}",
+    "undatetimeable": "Cannot build datetime using {type}: {datetime}",
+    "unmodelable": "Cannot build {model} model using {type}: {data}",
+    "unsyncable": "Cannot sync {model} with no id",
     "wrong_param": "Parameter '{param}' for {module}::{action} must be {type}; {actual} provided\n  {description}"
   },
   "sandbox": {

--- a/tests/Resource/CloudAccount/BackupTest.php
+++ b/tests/Resource/CloudAccount/BackupTest.php
@@ -14,7 +14,11 @@ use Nexcess\Sdk\ {
   Resource\CloudAccount\Backup,
   Resource\CloudAccount\CloudAccountException,
   Resource\CloudAccount\Endpoint,
-  Resource\CloudAccount\Entity,
+  Resource\CloudAccount\Entity as CloudAccount,
+  Resource\CloudAccount\Backup,
+  Resource\PromisedResource,
+  Resource\Promise,
+  Resource\Collection,
   Resource\Model,
   Resource\Promise,
   Tests\Resource\ModelTestCase,
@@ -49,7 +53,7 @@ class BackupTest extends ModelTestCase {
     $filename = 'filename.tgz';
     $force = false;
 
-    $entity  = new Entity();
+    $entity  = new CloudAccount();
     $entity->sync(['id' => 1]);
 
     $backup = new Backup();
@@ -86,7 +90,7 @@ class BackupTest extends ModelTestCase {
   public function testDelete() {
     $filename = 'filename.tgz';
 
-    $entity  = new Entity();
+    $entity  = new CloudAccount();
     $entity->sync(['id' => 1]);
 
     $backup = new Backup();
@@ -161,7 +165,7 @@ class BackupTest extends ModelTestCase {
    * @covers Backup::getCloudAccount
    */
   public function testGetSetCloudAccount() {
-    $entity = new Entity();
+    $entity  = new CloudAccount();
     $entity->sync(['id' => 1]);
 
     $backup = new Backup;
@@ -174,21 +178,13 @@ class BackupTest extends ModelTestCase {
    * @covers Backup::setCloudAccount
    */
   public function testWhenComplete() {
-    $entity  = new Entity();
-    $entity->sync(['id' => 1]);
-
-    $backup = new Backup();
-    $backup->setCloudAccount($entity);
-    $promise = new Promise($backup, function () {});
-
+    $backup = $this->_getSubject()->setCloudAccount(new CloudAccount());
     $endpoint = $this->createMock(Endpoint::class);
-    $endpoint->method('whenBackupComplete')
-      ->with(
-        $this->equalTo($backup),
-        $this->equalTo([])
-      )->willReturn($promise);
+    $endpoint->expects($this->once())
+      ->method('whenBackupComplete')
+      ->willReturn(new Promise($backup, function () {}));
     $backup->setApiEndpoint($endpoint);
-    $this->assertEquals($promise, $backup->whenComplete([]));
+    $backup->whenComplete();
   }
 
   /**

--- a/tests/Resource/CloudAccount/BackupTest.php
+++ b/tests/Resource/CloudAccount/BackupTest.php
@@ -15,12 +15,9 @@ use Nexcess\Sdk\ {
   Resource\CloudAccount\CloudAccountException,
   Resource\CloudAccount\Endpoint,
   Resource\CloudAccount\Entity as CloudAccount,
-  Resource\CloudAccount\Backup,
   Resource\PromisedResource,
   Resource\Promise,
-  Resource\Collection,
   Resource\Model,
-  Resource\Promise,
   Tests\Resource\ModelTestCase,
   Util\Config
 };

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -478,7 +478,10 @@ class EndpointTest extends EndpointTestCase {
 
       $sandbox->makeResponse('*', 200, [$incomplete]);
       $sandbox->makeResponse('*', 200, [$complete]);
-      $this->assertTrue($promise->wait()->get('complete'));
+      $resolved = $promise->wait();
+      $this->assertInstanceOf(Backup::class, $resolved);
+      $this->assertTrue($resolved->equals($backup));
+      $this->assertTrue($resolved->get('complete'));
     });
   }
 }

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -18,8 +18,9 @@ use org\bovigo\vfs\vfsStream;
 
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Endpoint,
-  Resource\CloudAccount\Entity,
+  Resource\CloudAccount\Entity as CloudAccount,
   Resource\CloudAccount\Backup,
+  Resource\Promise,
   Resource\ResourceException,
   Resource\VirtGuestCloud\Entity as Service,
   Tests\Resource\EndpointTestCase,
@@ -62,7 +63,7 @@ class EndpointTest extends EndpointTestCase {
   protected const _SUBJECT_FQCN = Endpoint::class;
 
   /** {@inheritDoc} */
-  protected const _SUBJECT_MODEL_FQCN = Entity::class;
+  protected const _SUBJECT_MODEL_FQCN = CloudAccount::class;
 
   /** {@inheritDoc} */
   protected const _SUBJECT_MODULE = 'CloudAccount';
@@ -182,14 +183,14 @@ class EndpointTest extends EndpointTestCase {
    * @covers Endpoint::createDevAccount
    * @dataProvider createDevAccountProvider
    *
-   * @param Entity $cloud Parent cloud account
+   * @param CloudAccount $cloud Parent cloud account
    * @param array $params Map of test input parameters
    * @param array|Throwable $expected Expected request payload;
    *  or an Exception if input is invalid
    * @param GuzzleResponse|callable|Throwable|null $response Response to queue
    */
   public function testCreateDevAccount(
-    Entity $cloud,
+    CloudAccount $cloud,
     array $params,
     $expected,
     $response = null
@@ -245,7 +246,7 @@ class EndpointTest extends EndpointTestCase {
    */
   public function createDevAccountProvider() : array {
     $fqcn = static::_SUBJECT_MODEL_FQCN;
-    $cloud = Entity::__set_state([
+    $cloud = CloudAccount::__set_state([
       '_values' => $this->_getResource(static::_RESOURCE_CLOUD) +
         ['account_id' => 1]
     ]);
@@ -300,7 +301,7 @@ class EndpointTest extends EndpointTestCase {
         ->method('getAvailablePhpVersions')
         ->willReturn($versions);
 
-      $entity = Entity::__set_state([
+      $entity = CloudAccount::__set_state([
         '_values' => ['account_id' => 1, 'service' => $service]
       ]);
       $this->assertEquals(
@@ -455,5 +456,29 @@ class EndpointTest extends EndpointTestCase {
         $api->getEndpoint(static::_SUBJECT_MODULE)
           ->deleteBackup($entity, $filename);
       });
+  }
+
+  /**
+   * @covers Endpoint::whenBackupComplete
+   */
+  public function testWhenBackupComplete() {
+    $this->_getSandbox()->play(function ($api, $sandbox) {
+      // all values must exist to prevent extraneous _tryToHydrate() calls
+      $incomplete = $this->_getResource(self::_RESOURCE_NEW_BACKUP) +
+        ['download_url' => ''];
+      $complete = ['complete' => true] + $incomplete;
+
+      $backup = $api->getModel(Backup::class)
+        ->sync($incomplete)
+        ->setCloudAccount(new CloudAccount());
+
+      $promise = $api->getEndpoint(static::_SUBJECT_MODULE)
+        ->whenBackupComplete($backup, [Promise::OPT_INTERVAL => 0]);
+      $this->assertInstanceOf(Promise::class, $promise);
+
+      $sandbox->makeResponse('*', 200, [$incomplete]);
+      $sandbox->makeResponse('*', 200, [$complete]);
+      $this->assertTrue($promise->wait()->get('complete'));
+    });
   }
 }


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12401

The goal in testing Promise methods is to test that the Promise polls correctly: not resolving before the desired condition is `true`, and not continuing to poll once it is.
- set `Promise::OPT_INTERVAL => 0` so polling doesn't slow tests down.
- prepare at least two responses for the sandbox:
  - one response where the desired condition is not yet met (e.g., `complete = false`)
  - one where it is (e.g., `complete = true`)
- make sure no model/response properties are `null`, soas not to cause extraneous _tryToHydrate() calls (if you get a `503 Service Unavailable` error from the sandbox, this is likely what's happening)

`wait()` for the Promise to resolve, and then assert that the correct model was returned and that the desired condition is now met.