### PR TITLE
Streamlining Backups

### DIFF
--- a/src/Resource/CloudAccount/Backup.php
+++ b/src/Resource/CloudAccount/Backup.php
@@ -60,20 +60,10 @@ class Backup extends Model {
    * @throws CloudAccountException
    */
   public function delete() : void {
-    if (! $this->isReal()) {
-      throw new CloudAccountException(
-        CloudAccountException::INVALID_BACKUP,
-        ['action' => __METHOD__]
-      );
-    }
-
     $endpoint = $this->_getEndpoint();
     assert($endpoint instanceof Endpoint);
 
-    $endpoint->deleteBackup(
-      $this->getCloudAccount(),
-      $this->get('filename')
-    );
+    $endpoint->deleteBackup($this);
   }
 
   /**
@@ -81,25 +71,12 @@ class Backup extends Model {
    *
    * @param string $path Where to save the file to
    * @param bool $force If true, overwrite existing file.
-   * @throws CloudAccountException
    */
   public function download(string $path, bool $force = false) : void {
-    if (! $this->isReal()) {
-      throw new CloudAccountException(
-        CloudAccountException::INVALID_BACKUP,
-        ['action' => __METHOD__]
-      );
-    }
-
     $endpoint = $this->_getEndpoint();
     assert($endpoint instanceof Endpoint);
 
-    $endpoint->downloadBackup(
-      $this->getCloudAccount(),
-      $this->get('filename'),
-      $path,
-      $force
-    );
+    $endpoint->downloadBackup($this, $path, $force);
   }
 
   /**

--- a/src/Resource/CloudAccount/Backup.php
+++ b/src/Resource/CloudAccount/Backup.php
@@ -180,7 +180,7 @@ class Backup extends Model {
       $endpoint = $this->_getEndpoint();
       assert($endpoint instanceof Endpoint);
 
-      $model = $endpoint->getBackup(
+      $model = $endpoint->retrieveBackup(
         $this->getCloudAccount(),
         $this->get('filename')
       );

--- a/src/Resource/CloudAccount/Backup.php
+++ b/src/Resource/CloudAccount/Backup.php
@@ -113,7 +113,7 @@ class Backup extends Model {
    * @return bool true if it has a non-empty file name
    */
   public function isReal() : bool {
-    return ! empty($this->_values['filename']);
+    return isset($this->_values['filename'], $this->_cloud_account);
   }
 
   /**

--- a/src/Resource/CloudAccount/CloudAccountException.php
+++ b/src/Resource/CloudAccount/CloudAccountException.php
@@ -34,6 +34,9 @@ class CloudAccountException extends Exception {
   /** @var int No cloud account associated with backup instance. */
   const OWNER_UNKNOWN = 6;
 
+  /** @var int Attempt to download an incomplete backup. */
+  const INCOMPLETE_BACKUP = 7;
+
   /** {@inheritDoc} */
   const INFO = [
     self::INVALID_PATH =>
@@ -47,6 +50,8 @@ class CloudAccountException extends Exception {
     self::INVALID_STREAM =>
       ['message' => 'resource.CloudAccount.Exception.invalid_stream'],
     self::OWNER_UNKNOWN =>
-      ['message' => 'resource.CloudAccount.Exception.owner_unknown']
+      ['message' => 'resource.CloudAccount.Exception.owner_unknown'],
+    self::INCOMPLETE_BACKUP =>
+      ['message' => 'resource.CloudAccount.Exception.incomplete_backup']
   ];
 }

--- a/src/Resource/CloudAccount/Endpoint.php
+++ b/src/Resource/CloudAccount/Endpoint.php
@@ -200,8 +200,8 @@ class Endpoint extends BaseEndpoint implements Creatable {
     assert($backup instanceof Backup);
 
     return $backup
-      ->sync($this->_findBackup($entity, $file_name))
-      ->setCloudAccount($entity);
+      ->setCloudAccount($entity)
+      ->sync($this->_findBackup($entity, $file_name));
   }
 
   /**
@@ -228,7 +228,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
     }
 
     $download_url = $backup->get('download_url');
-    if (empty($download_url)) {
+    if (empty($download_url) || $backup->get('complete') === false) {
       throw new CloudAccountException(
         CloudAccountException::INCOMPLETE_BACKUP,
         ['action' => __METHOD__, 'filename' => $backup->get('filename')]

--- a/src/Resource/CloudAccount/Endpoint.php
+++ b/src/Resource/CloudAccount/Endpoint.php
@@ -172,7 +172,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
    * @return Collection Of Backups
    * @throws ApiException If request fails
    */
-  public function getBackups(Entity $entity) : Collection {
+  public function listBackups(Entity $entity) : Collection {
     $collection = new Collection(Backup::class);
 
     foreach ($this->_fetchBackupList($entity) as $backup_data) {
@@ -195,7 +195,7 @@ class Endpoint extends BaseEndpoint implements Creatable {
    * @return Backup
    * @throws ApiException If request fails
    */
-  public function getBackup(Entity $entity, string $file_name) : Backup {
+  public function retrieveBackup(Entity $entity, string $file_name) : Backup {
     $backup = $this->getModel(Backup::class);
     assert($backup instanceof Backup);
 

--- a/src/Resource/CloudAccount/Entity.php
+++ b/src/Resource/CloudAccount/Entity.php
@@ -155,11 +155,11 @@ class Entity extends Model {
    *
    * @return Collection
    */
-  public function getBackups() : Collection {
+  public function listBackups() : Collection {
     $endpoint = $this->_getEndpoint();
     assert($endpoint instanceof Endpoint);
 
-    return $endpoint->getBackups($this);
+    return $endpoint->listBackups($this);
   }
 
   /**
@@ -167,10 +167,10 @@ class Entity extends Model {
    *
    * @return Backup
    */
-  public function getBackup(string $filename) : Backup {
+  public function retrieveBackup(string $filename) : Backup {
     $endpoint = $this->_getEndpoint();
     assert($endpoint instanceof Endpoint);
 
-    return $endpoint->getBackup($this, $filename);
+    return $endpoint->retrieveBackup($this, $filename);
   }
 }

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -45,6 +45,7 @@
       "Exception": {
         "backup_not_found": "No Cloud Account Backup was found with the name '{name}'",
         "file_exists": "The target download file '{filename}' already exists; not overwriting",
+        "incomplete_backup": "{action}() failed: backup is incomplete: {filename}",
         "invalid_backup": "{action}() failed: invalid Backup object (filename is empty)",
         "invalid_path": "The target download directory '{filename}' does not exist or is not writable",
         "invalid_stream": "The target download file '{filename}' could not be opened for writing",

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -46,7 +46,7 @@
         "backup_not_found": "No Cloud Account Backup was found with the name '{name}'",
         "file_exists": "The target download file '{filename}' already exists; not overwriting",
         "incomplete_backup": "{action}() failed: backup is incomplete: {filename}",
-        "invalid_backup": "{action}() failed: invalid Backup object (filename is empty)",
+        "invalid_backup": "{action}() failed: invalid Backup object (filename and/or CloudAccount is empty)",
         "invalid_path": "The target download directory '{filename}' does not exist or is not writable",
         "invalid_stream": "The target download file '{filename}' could not be opened for writing",
         "owner_unknown": "No owner Cloud Account object is set on this Backup ('{filename}')"

--- a/tests/Resource/CloudAccount/BackupTest.php
+++ b/tests/Resource/CloudAccount/BackupTest.php
@@ -60,25 +60,13 @@ class BackupTest extends ModelTestCase {
     $endpoint->expects($this->once())
       ->method('downloadBackup')
       ->with(
-        $this->equalTo($entity),
-        $this->equalTo($filename),
+        $this->equalTo($backup),
         $this->equalTo($path),
         $this->equalTo($force)
       );
     $backup->setApiEndpoint($endpoint);
     $backup->sync(['filename' => $filename]);
     $backup->download($path);
-  }
-
-  /**
-   * @covers Backup::download
-   */
-  public function testDownloadFailure() {
-    $this->setExpectedException(
-      new CloudAccountException(CloudAccountException::INVALID_BACKUP)
-    );
-
-    (new Backup())->download('some/path');
   }
 
   /**
@@ -96,26 +84,11 @@ class BackupTest extends ModelTestCase {
     $endpoint = $this->createMock(Endpoint::class);
     $endpoint->expects($this->once())
       ->method('deleteBackup')
-      ->with(
-        $this->equalTo($entity),
-        $this->equalTo($filename)
-      );
+      ->with($this->equalTo($backup));
     $backup->setApiEndpoint($endpoint);
     $backup->sync(['filename' => $filename]);
     $backup->delete();
   }
-
-  /**
-   * @covers Backup::download
-   */
-  public function testDeleteFailure() {
-    $this->setExpectedException(
-      new CloudAccountException(CloudAccountException::INVALID_BACKUP)
-    );
-
-    (new Backup())->delete();
-  }
-
 
   /**
    * @covers backup::equals

--- a/tests/Resource/CloudAccount/BackupTest.php
+++ b/tests/Resource/CloudAccount/BackupTest.php
@@ -94,8 +94,13 @@ class BackupTest extends ModelTestCase {
    * @covers backup::equals
    */
   public function testEquals() {
-    $model = $this->_getSubject()->sync(['filename' => 'filename.tgz']);
-    $other = $this->_getSubject()->sync(['filename' => 'filename.tgz']);
+    $cloud_account = new CloudAccount();
+    $model = $this->_getSubject()
+      ->setCloudAccount($cloud_account)
+      ->sync(['filename' => 'filename.tgz']);
+    $other = $this->_getSubject()
+      ->setCloudAccount($cloud_account)
+      ->sync(['filename' => 'filename.tgz']);
 
     $this->assertTrue(
       $model->equals($other),
@@ -126,7 +131,9 @@ class BackupTest extends ModelTestCase {
    */
   public function testIsReal() {
     $backup = new Backup();
-    $backup->sync(['filename' => 'filename.tgz']);
+    $backup
+      ->setCloudAccount(new CloudAccount())
+      ->sync(['filename' => 'filename.tgz']);
     $this->assertTrue($backup->isReal());
   }
 

--- a/tests/Resource/CloudAccount/EndpointTest.php
+++ b/tests/Resource/CloudAccount/EndpointTest.php
@@ -394,7 +394,7 @@ class EndpointTest extends EndpointTestCase {
 
       $backup = Backup::__set_state([
         '_values' => $this->_getResource(static::_RESOURCE_BACKUPS)[0]
-      ]);
+      ])->setCloudAccount(new CloudAccount());
       $endpoint = $api->getEndpoint(static::_SUBJECT_MODULE);
       $endpoint->downloadBackup($backup, $path);
 
@@ -433,7 +433,7 @@ class EndpointTest extends EndpointTestCase {
       // valid backup, but not complete (no download_url)
       $backup = Backup::__set_state([
         '_values' => ['filename' => 'filename.tgz']
-      ]);
+      ])->setCloudAccount(new CloudAccount());
       $api->getEndpoint(static::_SUBJECT_MODULE)
         ->downloadBackup($backup, 'some/path');
     });
@@ -469,7 +469,7 @@ class EndpointTest extends EndpointTestCase {
 
       $backup = Backup::__set_state([
         '_values' => $this->_getResource(static::_RESOURCE_BACKUPS)[0]
-      ]);
+      ])->setCloudAccount(new CloudAccount());
       $api->getEndpoint(static::_SUBJECT_MODULE)
         ->downloadBackup($backup, $path);
     });

--- a/tests/Resource/CloudAccount/EntityTest.php
+++ b/tests/Resource/CloudAccount/EntityTest.php
@@ -102,14 +102,14 @@ class EntityTest extends ModelTestCase {
   }
 
   /**
-   * @covers Entity::getBackups
+   * @covers Entity::listBackups
    */
-  public function testGetBackups() {
+  public function testListBackups() {
     $entity = $this->_getSubject();
 
     $collection = new Collection(Backup::class);
     $endpoint = $this->createMock(Endpoint::class);
-    $endpoint->method('getBackups')
+    $endpoint->method('listBackups')
       ->with($this->equalTo($entity))
       ->willReturn($collection);
 
@@ -117,15 +117,15 @@ class EntityTest extends ModelTestCase {
 
     $this->assertEquals(
       $collection,
-      $entity->getBackups(),
-      'invokes $endpoint->getBackups($entity)'
+      $entity->listBackups(),
+      'invokes $endpoint->listBackups($entity)'
     );
   }
 
   /**
-   * @covers Entity::getBackup
+   * @covers Entity::retrieveBackup
    */
-  public function testGetBackup() {
+  public function testRetrieveBackup() {
     $entity = $this->_getSubject();
     $filename = 'filename.tgz';
 
@@ -135,7 +135,7 @@ class EntityTest extends ModelTestCase {
       ->willReturn($filename);
 
     $endpoint = $this->createMock(Endpoint::class);
-    $endpoint->method('getBackup')
+    $endpoint->method('retrieveBackup')
       ->with($this->equalTo($entity), $this->equalTo($filename))
       ->willReturn($backup);
 
@@ -143,8 +143,8 @@ class EntityTest extends ModelTestCase {
 
     $this->assertEquals(
       $filename,
-      $entity->getBackup($filename)->get('filename'),
-      'invokes $endpoint->getBackups($entity)'
+      $entity->retrieveBackup($filename)->get('filename'),
+      'invokes $endpoint->listBackups($entity)'
     );
   }
 


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12396

- renames Backup list/retrieve methods for consistency
- `_findBackup` returns raw payload (as an array; this was not previously available and imposed extra processing requirements on several methods)
- `downloadBackup` and `deleteBackup` take a Backup instance
- `isReal` additionally checks that an owner CloudAccount is set (we need both the account and the filename to retrieve/sync)