### PR TITLE
Make Creatable a Marker Interface

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -149,6 +149,7 @@ class Client {
         );
       }
 
+      // @phan-suppress-next-line PhanUndeclaredMethod
       return $endpoint->create($arg);
     }
 

--- a/src/Resource/Creatable.php
+++ b/src/Resource/Creatable.php
@@ -9,23 +9,12 @@ declare(strict_types  = 1);
 
 namespace Nexcess\Sdk\Resource;
 
-use Nexcess\Sdk\ {
-  ApiException,
-  Resource\Modelable,
-  Resource\Readable
-};
-
 /**
- * Interface for API endpoints which can create new resources.
+ * Interface for API endpoints which can create new resources on the API.
+ *
+ * Such endpoints MUST have a create() method,
+ * though the method's signature will vary based on the inputs required.
+ *
+ * All endpoint create() methods MUST return a Modelable instance.
  */
-interface Creatable extends Readable {
-
-  /**
-   * Creates a new item.
-   *
-   * @param array $data Map of values for new item
-   * @return Modelable
-   * @throws ApiException If request fails
-   */
-  public function create(array $data) : Modelable;
-}
+interface Creatable extends Readable {}


### PR DESCRIPTION
`create()` methods all need different signatures.